### PR TITLE
Import + Export features (Functions + Constants)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "cppdbg",
       "request": "launch",
       "program": "${workspaceFolder}/Debug/tmpl-script/tmpl-script",
-      "args": ["test"],
+      "args": ["test", "wheel"],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/example",
       "environment": [],

--- a/CLIBRARY.md
+++ b/CLIBRARY.md
@@ -1,4 +1,8 @@
 
+# TODOs to complete before this can be implemented
+
+- Define custom types
+- Objects support
 
 # Example of creating C library binded to tmpl
 

--- a/CLIBRARY.md
+++ b/CLIBRARY.md
@@ -1,0 +1,75 @@
+
+
+# Example of creating C library binded to tmpl
+
+STD_lib/
+---> lib.ctmpl
+---> lib.c
+
+```c
+typedef enum {
+    INT,
+    STRING
+} ArgType;
+
+typedef struct {
+    ArgType type;
+    void* value;
+} Argument;
+
+typedef struct {
+    Argument* args;
+} State;
+```
+
+```cpp
+char* msg = "hello, world!";
+State* state = new State {.args = {Argument{.type=ArgType.INT, .value=}}};
+void* data = c_print(state);
+```
+
+## lib.ctmpl:
+
+```
+@require"c_lib"
+@require"lib.prelude"
+
+@extern fn c_print(cstr message) : int
+@extern fn c_write(cint fd, cstr message) : int
+
+export fn print(string message) : int {
+    return c_print(str_to_cstr(message));
+}
+
+export fn write(int fd, string message) : int {
+    return c_write(fd, message);
+}
+
+```
+
+## lib.c:
+```c
+#include <stdio.h>
+
+int c_print(State* state)
+{
+    char* message = state->data;
+    printf("%s", message);
+    return strlen(message);
+}
+
+int c_write(State* state)
+{
+    
+}
+
+```
+
+## main.tmpl
+
+@require"std"
+
+->main {
+    print("Hello world!");
+}
+

--- a/example/.tmpl/math/constants.tmpl
+++ b/example/.tmpl/math/constants.tmpl
@@ -1,0 +1,4 @@
+
+
+export const float PI = 3.1415926;
+

--- a/example/.tmpl/math/floats.tmpl
+++ b/example/.tmpl/math/floats.tmpl
@@ -1,0 +1,6 @@
+@require"constants"
+
+export fn add_floats(float a, float b) : float {
+    return (a + b) * PI;
+}
+

--- a/example/.tmpl/negative.tmpl
+++ b/example/.tmpl/negative.tmpl
@@ -1,0 +1,6 @@
+
+
+export fn getNegativeFloat(float value) : float {
+    return -value;
+}
+

--- a/example/.tmpl/test.tmpl
+++ b/example/.tmpl/test.tmpl
@@ -1,14 +1,11 @@
-
-fn add_floats(float a, float b) : float {
-    return a + b;
-}
+@require"math/floats"
+@require"negative"
 
 ->main{
-    return add_floats(3.1415, 1.22,);
+    return add_floats(3.1415, 1.22);
 }
 
 ->wheel {
-    var float PI = 3.1415;
-    return PI;
+    return getNegativeFloat(PI);
 }
 

--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -1,6 +1,5 @@
 #ifndef ERROR_H
 #define ERROR_H
-#include <iostream>
 #include <string>
 #include <memory>
 #include "location.h"
@@ -59,6 +58,7 @@ namespace Prelude
 		void ArgMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc);
 		void ReturnMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc);
         void ArgsParamsExhausted(std::string filename, std::string name, size_t argsSize, size_t paramsSize, Location loc);
+        void UnaryOperatorNotSupported(std::string filename, std::string op, Runtime::ValueType metType, Location loc);
     public: // CliRunner
         void NotEnoughArgs(int expected, int got, bool atLeast);
         void InvalidArgument(std::string arg, std::string message);

--- a/tmpl-script/include/interpreter.h
+++ b/tmpl-script/include/interpreter.h
@@ -1,17 +1,19 @@
 #ifndef INTERPRETER_H
 #define INTERPRETER_H
 #include <memory>
-#include "node/program.h"
 #include "node/return.h"
+#include "node/program.h"
 #include "parser.h"
 #include "node.h"
-#include "node/expression.h"
 #include "node/literal.h"
 #include "node/var_declaration.h"
 #include "node/identifier.h"
 #include "node/logical.h"
 #include "node/procedure.h"
 #include "node/function.h"
+#include "node/macros.h"
+#include "node/export.h"
+#include "node/unary.h"
 #include "interpreter/environment.h"
 #include "interpreter/value.h"
 
@@ -26,6 +28,8 @@ namespace Runtime
 		std::shared_ptr<Environment<Procedure>> m_procedures;
 		std::shared_ptr<Environment<Fn>> m_functions;
 
+        std::string m_filename;
+
 	public:
         Interpreter(std::shared_ptr<Parser> parser,
                 std::shared_ptr<Environment<Variable>> env_vars,
@@ -34,11 +38,14 @@ namespace Runtime
             : m_parser(parser),
             m_variables(env_vars),
             m_procedures(env_procedures),
-            m_functions(env_functions) { }
+            m_functions(env_functions),
+            m_filename(parser->GetFilename()) { }
 
 	public:
 		std::shared_ptr<Value> Execute(std::shared_ptr<Node> node);
         void Evaluate(std::shared_ptr<ProgramNode> program);
+        void ImportModule(std::shared_ptr<RequireMacro> require);
+        void EvaluateModule(std::shared_ptr<ProgramNode> program);
 
 	private:
 		std::shared_ptr<Value> EvaluateExpression(std::shared_ptr<ExpressionNode> expr);
@@ -46,16 +53,22 @@ namespace Runtime
 		std::shared_ptr<Value> EvaluateIdentifier(std::shared_ptr<IdentifierNode> identifier);
 		std::shared_ptr<Value> EvaluateCondition(std::shared_ptr<Condition> condition);
 		std::shared_ptr<Value> EvaluateTernary(std::shared_ptr<TernaryNode> ternary);
+        std::shared_ptr<Value> EvaluateUnary(std::shared_ptr<UnaryNode> unary);
         std::shared_ptr<Value> EvaluateReturn(std::shared_ptr<ReturnNode> ret);
         std::shared_ptr<Value> EvaluateFunctionCall(std::shared_ptr<FunctionCall> ret);
 
-	public:
+	private:
 		void EvaluateVariableDeclaration(std::shared_ptr<VarDeclaration> varDecl);
 		void EvaluateProcedureDeclaration(std::shared_ptr<ProcedureDeclaration> procDecl);
         void EvaluateFunctionDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl);
+        void EvaluateExportStatement(std::shared_ptr<ExportStatement> exportStmt);
 
-	public:
+	private:
 		ValueType EvaluateType(std::shared_ptr<Node> typeNode);
+
+    private:
+        inline std::string GetFilename() const { return m_filename; }
+        void SetFilename(std::string filename) { m_filename = filename; }
 	};
 }
 

--- a/tmpl-script/include/interpreter/environment.h
+++ b/tmpl-script/include/interpreter/environment.h
@@ -65,19 +65,24 @@ namespace Runtime
 	{
 	private:
 		std::shared_ptr<Node> m_body;
-        std::vector<FnParam> m_params;
+        std::vector<std::shared_ptr<FnParam>> m_params;
         ValueType m_ret_type;
+    private:
+        size_t m_index;
 
 	public:
 		Fn(std::shared_ptr<Node> body, ValueType retType)
-			: m_body(body), m_ret_type(retType), m_params(std::vector<FnParam>()) {}
+			: m_body(body), m_ret_type(retType), m_params(std::vector<std::shared_ptr<FnParam>>()), m_index(0) {}
 
     public:
-        void AddParam(FnParam param) { m_params.push_back(param); }
+        void AddParam(std::shared_ptr<FnParam> param) { m_params.push_back(param); }
 
 	public:
 		inline std::shared_ptr<Node> GetBody() { return m_body; }
-        inline std::vector<FnParam> GetParams() { return m_params; }
+        inline bool HasParams() { return m_index < m_params.size(); }
+        inline std::shared_ptr<FnParam> GetNextParam() { return m_params[m_index++]; }
+        inline size_t GetParamsSize() { return m_params.size(); }
+        inline size_t GetParamsIndex() { return m_index; }
         inline ValueType GetReturnType() { return m_ret_type; }
 
 		friend std::ostream &operator<<(std::ostream &stream, const Fn &fn)

--- a/tmpl-script/include/node.h
+++ b/tmpl-script/include/node.h
@@ -28,7 +28,9 @@ namespace AST
 		ProcedureDecl,
         Return,
         FnDecl,
-	};
+        Require,
+        Export,
+    };
 
 	class Node
 	{

--- a/tmpl-script/include/node/export.h
+++ b/tmpl-script/include/node/export.h
@@ -1,0 +1,28 @@
+
+#include "../node.h"
+#include <memory>
+
+namespace AST
+{
+    namespace Nodes
+    {
+        class ExportStatement : public Node
+        {
+        private:
+            std::shared_ptr<Node> m_target;
+        public:
+            ExportStatement(std::shared_ptr<Node> target, Location loc)
+                : m_target(target), Node(loc) { }
+            ~ExportStatement() = default;
+        public:
+            inline NodeType GetType() const override { return NodeType::Export; }
+
+        public:
+            std::string Format() const override;
+
+        public:
+            inline std::shared_ptr<Node> GetTarget() const { return m_target; }
+        };
+    }
+}
+

--- a/tmpl-script/include/node/function.h
+++ b/tmpl-script/include/node/function.h
@@ -49,7 +49,7 @@ namespace AST
         {
         private:
             std::shared_ptr<IdentifierNode> m_name;
-            std::vector<FunctionParam> m_params;
+            std::vector<std::shared_ptr<FunctionParam>> m_params;
             std::shared_ptr<Node> m_ret_type;
             std::shared_ptr<Statements::StatementsBody> m_body;
         private:
@@ -61,13 +61,14 @@ namespace AST
                     Location loc
                     )
                 : m_name(name),
-                m_params(std::vector<FunctionParam>()),
+                m_params(std::vector<std::shared_ptr<FunctionParam>>()),
                 m_ret_type(nullptr),
                 m_body(body),
+                m_index(0),
                 Node(loc) { }
             ~FunctionDeclaration() = default;
         public:
-            void AddParam(FunctionParam param) { m_params.push_back(param); }
+            void AddParam(std::shared_ptr<FunctionParam> param);
             void SetReturnType(std::shared_ptr<Node> retType) { m_ret_type = retType; }
         public:
             inline std::string GetName() const { return m_name->GetName(); }
@@ -75,7 +76,7 @@ namespace AST
             inline std::shared_ptr<Statements::StatementsBody> GetBody() const { return m_body; }
         public: // Iterate
             inline bool HasParams() { return m_params.size() > m_index; }
-            FunctionParam GetNextParam() { return m_params[m_index++]; }
+            std::shared_ptr<FunctionParam> GetNextParam() { return m_params[m_index++]; }
 		public:
 			inline NodeType GetType() const override { return NodeType::FnDecl; }
             std::string Format() const override;

--- a/tmpl-script/include/node/macros.h
+++ b/tmpl-script/include/node/macros.h
@@ -1,0 +1,27 @@
+
+
+#include "../node.h"
+
+namespace AST
+{
+    namespace Nodes
+    {
+        class RequireMacro : public Node
+        {
+        private:
+            std::string m_module;
+        public:
+            RequireMacro(std::string module, Location loc)
+                : m_module(module), Node(loc) { }
+            ~RequireMacro() = default;
+        public:
+            inline std::string GetModule() const { return m_module; }
+        public:
+            inline NodeType GetType() const override { return NodeType::Require; };
+
+        public:
+            std::string Format() const override;
+        };
+    }
+}
+

--- a/tmpl-script/include/node/unary.h
+++ b/tmpl-script/include/node/unary.h
@@ -1,5 +1,6 @@
 #ifndef UNARY_H
 #define UNARY_H
+#include <memory>
 #include"../node.h"
 
 namespace AST
@@ -22,6 +23,9 @@ namespace AST
 			UnaryNode(UnaryOperator op, std::shared_ptr<Node> target, Location loc)
                 : m_operator(op), m_target(target), Node(loc) {}
 			~UnaryNode() {}
+        public:
+            inline UnaryOperator GetOperator() const { return m_operator; }
+            inline std::shared_ptr<Node> GetTarget() const { return m_target; }
 		public:
 			inline NodeType GetType() const override { return NodeType::Unary; }
 		public:

--- a/tmpl-script/include/parser.h
+++ b/tmpl-script/include/parser.h
@@ -55,6 +55,9 @@ namespace AST
 		std::shared_ptr<Node> ProcedureDeclaration();
         std::shared_ptr<Node> ReturnStatement();
         std::shared_ptr<Node> FunctionDeclaration();
+        std::shared_ptr<Node> ExportStmt();
+    private: // Macros
+        std::shared_ptr<Node> RequireStatement();
 	};
 }
 

--- a/tmpl-script/include/token.h
+++ b/tmpl-script/include/token.h
@@ -51,6 +51,7 @@ namespace AST
 		Const,
         Return,
         Fn,
+        Export,
 		_EOF,
 	};
 
@@ -99,6 +100,7 @@ namespace AST
 		"const",
         "return",
         "fn",
+        "export",
 		"EOF",
 	};
 

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -6,6 +6,11 @@ using namespace AST;
 
 namespace Prelude
 {
+    // TODO: Refactor error.cpp:
+    // 1. create separate function for logging out error location + show relative path to .tmpl file
+    // 2. provide error location in all error kinds
+    // 3. use stderr instead of stdout
+    // 4. colorize error location with grey (like this comment)
 	ErrorManager::ErrorManager() {}
 	ErrorManager::~ErrorManager() {}
 	void ErrorManager::RaiseError(std::string errorMessage)
@@ -55,6 +60,7 @@ namespace Prelude
 	}
 	void ErrorManager::VarMismatchType(std::string name, Runtime::ValueType type, Runtime::ValueType expectedType)
 	{
+        // TODO: allow defining double type variable with float value (casting) and opposite direction
 		std::cout << "RuntimeError: Type mismatch for variable '" << name << "'. Expected type '" << (int)expectedType << "' but got '" << (int)type << "'" << std::endl;
 		std::exit(-1);
 	}
@@ -106,15 +112,23 @@ namespace Prelude
         
         if (argsSize < paramsSize)
         {
-            std::cout << "Exhausted args for function '" << name << "'";
+            std::cout << "Exhausted args for function '" << name << "'. Needs to provide " << paramsSize << " arguments but only " << argsSize << " provided";
         }
         else
         {
-            std::cout << "Exhausted params for function '" << name << "'";
+            std::cout << "Exhausted params for function '" << name << "'. Needs to provide " << paramsSize << " arguments but " << argsSize << " provided";
         }
         std::cout << '\n';
 
         exit(-1);
+    }
+
+    void ErrorManager::UnaryOperatorNotSupported(std::string filename, std::string op, Runtime::ValueType metType, Location loc)
+    {
+        std::cout << "[" << filename << ":" << loc.line << ":" << loc.col << "] ";
+        std::cout << "RuntimeError: Unary operator '" << op
+            << "' is not allowed with type '" << std::to_string((int)metType) << "'" << std::endl;
+        std::exit(-1);
     }
 
     void ErrorManager::UndeclaredFunction(std::string filename, std::shared_ptr<Nodes::IdentifierNode> id)

--- a/tmpl-script/src/interpreter/expr.cpp
+++ b/tmpl-script/src/interpreter/expr.cpp
@@ -1,9 +1,58 @@
 
 #include "../../include/interpreter.h"
+#include <memory>
+#include <cassert>
 
 namespace Runtime
 {
     using namespace AST::Nodes;
+
+    std::shared_ptr<Value> Interpreter::EvaluateUnary(std::shared_ptr<UnaryNode> unary)
+    {
+        std::shared_ptr<Value> target = Execute(unary->GetTarget());
+
+        if (unary->GetOperator() == UnaryNode::UnaryOperator::Positive)
+        {
+            return target;
+        }
+
+        if (unary->GetOperator() == UnaryNode::UnaryOperator::Negative)
+        {
+            switch(target->GetType())
+            {
+                case ValueType::Integer:
+                {
+                    std::shared_ptr<IntegerValue> val = std::dynamic_pointer_cast<IntegerValue>(target);
+                    return std::make_shared<IntegerValue>(std::make_shared<int>(-(*val->GetValue())));
+                }
+                case ValueType::Float:
+                {
+                    std::shared_ptr<FloatValue> val = std::dynamic_pointer_cast<FloatValue>(target);
+                    return std::make_shared<FloatValue>(std::make_shared<float>(-(*val->GetValue())));
+                }
+                case ValueType::Double:
+                {
+                    std::shared_ptr<DoubleValue> val = std::dynamic_pointer_cast<DoubleValue>(target);
+                    return std::make_shared<DoubleValue>(std::make_shared<double>(-(*val->GetValue())));
+                }
+                default:
+                    Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+                    errorManager.UnaryOperatorNotSupported(GetFilename(), "-", target->GetType(), unary->GetLocation());
+                    return nullptr;
+            }
+        }
+
+        if (unary->GetOperator() == UnaryNode::UnaryOperator::Not)
+        {
+            // TODO: add boolean value support
+            Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+            errorManager.UnaryOperatorNotSupported(GetFilename(), "!", target->GetType(), unary->GetLocation());
+            return nullptr;
+        }
+
+        assert(false && "Unreachable code. Should have handled all unary operators");
+        return nullptr;
+    }
 
 	std::shared_ptr<Value> Interpreter::EvaluateTernary(std::shared_ptr<TernaryNode> ternary)
 	{

--- a/tmpl-script/src/interpreter/fn_call.cpp
+++ b/tmpl-script/src/interpreter/fn_call.cpp
@@ -21,7 +21,7 @@ namespace Runtime
             if (!m_functions->HasItem(fnName))
             {
                 Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-                errorManager.UndeclaredFunction(m_parser->GetFilename(), callee);
+                errorManager.UndeclaredFunction(GetFilename(), callee);
                 return nullptr;
             }
 
@@ -30,41 +30,40 @@ namespace Runtime
             std::shared_ptr<Environment<Variable>> currentScope = m_variables;
             std::shared_ptr<Environment<Variable>> variables = std::make_shared<Environment<Variable>>(m_variables);
 
-            auto params = fn->GetParams();
             auto args = fnCall->GetArgs();
 
-            if (params.size() != args->size())
+            if (fn->GetParamsSize() != args->size())
             {
                 Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
                 errorManager.ArgsParamsExhausted(
-                        m_parser->GetFilename(),
+                        GetFilename(),
                         fnName,
                         args->size(),
-                        params.size(),
+                        fn->GetParamsSize(),
                         fnCall->GetLocation());
                 return nullptr;
             }
 
-            for (size_t i = 0; i < params.size(); i++)
+            while (fn->HasParams())
             {
-                FnParam param = params[i];
-                std::shared_ptr<Node> arg = (*args)[i];
+                std::shared_ptr<Node> arg = (*args)[fn->GetParamsIndex()];
+                std::shared_ptr<FnParam> param = fn->GetNextParam();
                 std::shared_ptr<Value> val = Execute(arg);
-                if (val->GetType() != param.GetType())
+                if (val->GetType() != param->GetType())
                 {
                     Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
                     errorManager.ArgMismatchType(
-                        m_parser->GetFilename(),
-                        param.GetName(),
+                        GetFilename(),
+                        param->GetName(),
                         val->GetType(),
-                        param.GetType(),
+                        param->GetType(),
                         arg->GetLocation()
                     );
                     return nullptr;
                 }
                 std::shared_ptr<Variable> var =
                     std::make_shared<Variable>(val->GetType(), val, false);
-                variables->AddItem(param.GetName(), var);
+                variables->AddItem(param->GetName(), var);
             }
 
             m_variables = variables;
@@ -76,7 +75,7 @@ namespace Runtime
             if (value->GetType() != fn->GetReturnType())
             {
                 Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-                errorManager.ReturnMismatchType(m_parser->GetFilename(), fnName, value->GetType(), fn->GetReturnType(), fnCall->GetLocation());
+                errorManager.ReturnMismatchType(GetFilename(), fnName, value->GetType(), fn->GetReturnType(), fnCall->GetLocation());
                 return nullptr;
             }
 

--- a/tmpl-script/src/interpreter/fn_decl.cpp
+++ b/tmpl-script/src/interpreter/fn_decl.cpp
@@ -18,10 +18,10 @@ namespace Runtime
 
         while (fnDecl->HasParams())
         {
-            FunctionParam param = fnDecl->GetNextParam();
-            ValueType paramType = EvaluateType(param.GetType());
-            std::string paramName = param.GetName()->GetName();
-            FnParam fnParam = FnParam(paramType, paramName);
+            std::shared_ptr<FunctionParam> param = fnDecl->GetNextParam();
+            ValueType paramType = EvaluateType(param->GetType());
+            std::string paramName = param->GetName()->GetName();
+            std::shared_ptr<FnParam> fnParam = std::make_shared<FnParam>(paramType, paramName);
             fn->AddParam(fnParam);
         }
 

--- a/tmpl-script/src/interpreter/identifier.cpp
+++ b/tmpl-script/src/interpreter/identifier.cpp
@@ -10,7 +10,7 @@ namespace Runtime
 		if (!m_variables->HasItem(identifier->GetName()))
 		{
 			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-			errorManager.UndeclaredVariable(m_parser->GetFilename(), identifier);
+			errorManager.UndeclaredVariable(GetFilename(), identifier);
 			return nullptr;
 		}
 		std::shared_ptr<Variable> var = m_variables->LookUp(identifier->GetName());

--- a/tmpl-script/src/interpreter/import.cpp
+++ b/tmpl-script/src/interpreter/import.cpp
@@ -1,0 +1,60 @@
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <cassert>
+#include "../../include/interpreter.h"
+
+namespace fs = std::filesystem;
+
+namespace Runtime
+{
+    using namespace AST::Nodes;
+
+    void Interpreter::EvaluateExportStatement(std::shared_ptr<ExportStatement> exportStmt)
+    {
+        auto target = exportStmt->GetTarget();
+        switch(target->GetType())
+        {
+            case NodeType::FnDecl:
+                EvaluateFunctionDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(target));
+                break;
+            case NodeType::VarDecl:
+                EvaluateVariableDeclaration(std::dynamic_pointer_cast<VarDeclaration>(target));
+                break;
+            default:
+                assert(false && "Unreachable. Should be handled by parser.");
+                return;
+        }
+    }
+
+    void Interpreter::ImportModule(std::shared_ptr<RequireMacro> require)
+    {
+        std::string module = require->GetModule();
+        fs::path currentPath = GetFilename();
+        fs::path modulePath = currentPath.parent_path() / (module + ".tmpl");
+
+        std::cout << "[DEBUG] Import module from '" << modulePath << "'" << std::endl;
+
+        std::ifstream moduleFile(modulePath);
+        if (!moduleFile.good())
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.FailedOpeningFile(modulePath);
+            return;
+        }
+
+        std::shared_ptr<Lexer> lexer = std::make_shared<Lexer>(moduleFile, modulePath);
+        lexer->Tokenize();
+
+        std::shared_ptr<Parser> parser = std::make_shared<Parser>(lexer);
+        parser->Parse();
+
+        std::shared_ptr<ProgramNode> program = std::dynamic_pointer_cast<ProgramNode>(parser->GetRoot());
+
+        SetFilename(modulePath);
+        EvaluateModule(program);
+        SetFilename(currentPath.string());
+    }
+}
+

--- a/tmpl-script/src/interpreter/import.cpp
+++ b/tmpl-script/src/interpreter/import.cpp
@@ -44,7 +44,7 @@ namespace Runtime
             return;
         }
 
-        std::shared_ptr<Lexer> lexer = std::make_shared<Lexer>(moduleFile, modulePath);
+        std::shared_ptr<Lexer> lexer = std::make_shared<Lexer>(moduleFile, modulePath.string());
         lexer->Tokenize();
 
         std::shared_ptr<Parser> parser = std::make_shared<Parser>(lexer);
@@ -52,7 +52,7 @@ namespace Runtime
 
         std::shared_ptr<ProgramNode> program = std::dynamic_pointer_cast<ProgramNode>(parser->GetRoot());
 
-        SetFilename(modulePath);
+        SetFilename(modulePath.string());
         EvaluateModule(program);
         SetFilename(currentPath.string());
     }

--- a/tmpl-script/src/interpreter/import.cpp
+++ b/tmpl-script/src/interpreter/import.cpp
@@ -40,7 +40,7 @@ namespace Runtime
         if (!moduleFile.good())
         {
             Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
-            errManager.FailedOpeningFile(modulePath);
+            errManager.FailedOpeningFile(modulePath.string());
             return;
         }
 

--- a/tmpl-script/src/interpreter/var_decl.cpp
+++ b/tmpl-script/src/interpreter/var_decl.cpp
@@ -23,7 +23,7 @@ namespace Runtime
         if (m_variables->HasItem(varName))
         {
 			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-			errorManager.VarAlreadyExists(m_parser->GetFilename(), varName, varDecl->GetLocation());
+			errorManager.VarAlreadyExists(GetFilename(), varName, varDecl->GetLocation());
 			return;
         }
 

--- a/tmpl-script/src/lexer.cpp
+++ b/tmpl-script/src/lexer.cpp
@@ -262,8 +262,10 @@ namespace AST
 			m_tokens.push_back(std::make_shared<Token>(TokenType::Const, m_line, m_col));
 		else if (*id == "return")
 			m_tokens.push_back(std::make_shared<Token>(TokenType::Return, m_line, m_col));
-        else if (*id == "fn")
+		else if (*id == "fn")
             m_tokens.push_back(std::make_shared<Token>(TokenType::Fn, m_line, m_col));
+		else if (*id == "export")
+            m_tokens.push_back(std::make_shared<Token>(TokenType::Export, m_line, m_col));
 		else
 		{
 			std::shared_ptr<Token::TypedValueHolder<std::string>> value = std::make_shared<Token::TypedValueHolder<std::string>>(std::make_shared<std::string>(*id));

--- a/tmpl-script/src/main.cpp
+++ b/tmpl-script/src/main.cpp
@@ -59,7 +59,6 @@ int main(int argc, char **argv)
 
     for (auto arg : args)
     {
-        std::cout << "[DEBUG] Adding arg: '" << arg << "'" << std::endl;
         std::shared_ptr<StringValue> argVal = std::make_shared<StringValue>(arg);
         argsList->AddItem(argVal);
     }

--- a/tmpl-script/src/node/export.cpp
+++ b/tmpl-script/src/node/export.cpp
@@ -1,0 +1,14 @@
+
+#include "../../include/node/export.h"
+
+namespace AST
+{
+    namespace Nodes
+    {
+        std::string ExportStatement::Format() const
+        {
+            return "Export(" + m_target->Format() + ")";
+        }
+    }
+}
+

--- a/tmpl-script/src/node/function.cpp
+++ b/tmpl-script/src/node/function.cpp
@@ -15,5 +15,10 @@ namespace AST
 		{
 			return "FnDecl(" + m_name->Format() + ", " + std::to_string(m_params.size()) + " params, returns " + m_ret_type->Format() + ")";
 		}
+
+        void FunctionDeclaration::AddParam(std::shared_ptr<FunctionParam> param)
+        {
+            m_params.push_back(param);
+        }
 	}
 }

--- a/tmpl-script/src/node/macros.cpp
+++ b/tmpl-script/src/node/macros.cpp
@@ -1,0 +1,14 @@
+
+#include "../../include/node/macros.h"
+
+namespace AST
+{
+    namespace Nodes
+    {
+        std::string RequireMacro::Format() const
+        {
+            return "Require(" + m_module + ")";
+        }
+    }
+}
+

--- a/tmpl-script/src/parser.cpp
+++ b/tmpl-script/src/parser.cpp
@@ -74,6 +74,33 @@ namespace AST
         case TokenType::Fn:
             stmt = FunctionDeclaration();
             break;
+        case TokenType::Export:
+            stmt = ExportStmt();
+            break;
+        case TokenType::At:
+        {
+            auto tokenType = Peek();
+            if (tokenType == TokenType::_EOF)
+            {
+                Prelude::ErrorManager& manager = GetErrorManager();
+                manager.UnexpectedEOF(token->GetLine(), token->GetColumn());
+                return nullptr;
+            }
+            Eat(TokenType::At);
+            // Macros
+            switch (tokenType)
+            {
+                case TokenType::Require:
+                    stmt = RequireStatement();
+                    break;
+                // TODO: add extern fn macro
+                default:
+                    Prelude::ErrorManager& manager = GetErrorManager();
+                    manager.UnexpectedToken(GetFilename(), m_lexer->SeekToken());
+                    return nullptr;
+            }
+            break;
+        }
 		default:
 			stmt = Ternary();
 			Eat(TokenType::Semicolon);

--- a/tmpl-script/src/parser/macros.cpp
+++ b/tmpl-script/src/parser/macros.cpp
@@ -1,0 +1,23 @@
+
+
+#include <memory>
+#include "../../include/parser.h"
+#include "../../include/node/macros.h"
+
+namespace AST
+{
+    using namespace AST::Nodes;
+
+    std::shared_ptr<Node> Parser::RequireStatement()
+    {
+        auto loc = m_lexer->GetToken()->GetLocation();
+        Eat(TokenType::Require);
+
+        auto token = m_lexer->GetToken();
+        Eat(TokenType::String);
+        std::shared_ptr<std::string> module = token->GetValue<std::string>();
+
+        return std::make_shared<RequireMacro>(*module, loc);
+    }
+}
+


### PR DESCRIPTION
Start for implementing C/CXX powered libraries bond to TMPL

## New Features:

- `@require` macro that searches for exported members in the path and imports them (declaring in environment)
- `export ...` statement allows you to export declared constant or function
- Fix for fn declaration not showing right amount of params (init m_index member with value 0)

#### Note

`@require` macro does open the target file and evaluate only it's exported members. At the runtime compiler is allowing only `export` and inner `@require` statements that will be recursively added as well.

## Example

Main `.tmpl` file:
```
@require"math/floats"
@require"negative"

->main{
    return add_floats(3.1415, 1.22);
}

->wheel {
    return getNegativeFloat(PI);
}
```

`math/floats.tmpl` file:
```
@require"constants"

export fn add_floats(float a, float b) : float {
    return (a + b) * PI;
}
```

`math/constants` file:
```
export const float PI = 3.1415926;
```

`negative.tmpl` file:
```
export fn getNegativeFloat(float value) : float {
    return -value;
}
```

### TODOs:

- Error Manager refactor
- Allow defining types and some kind of classes
- Better typing (more restriction)