### PR TITLE
Refactor Error

### DIFF
--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -35,23 +35,26 @@ namespace Prelude
 
 	public:
 		void NoInputFile();
+    
+    private:
+        void LogFileLocation(std::string filename, Location loc, std::string prefix);
 
 	public: // Lexer (Tokenizer)
-		void UnexpectedCharacter(char ch, size_t line, size_t col);
-		void UnexpectedEOF(size_t line, size_t col);
+		void UnexpectedCharacter(std::string filename, char ch, size_t line, size_t col);
+		void UnexpectedEOF(std::string filename, size_t line, size_t col);
 
 	public: // Parser
-		void UnexpectedEofWhileToken(TokenType tokenType, size_t line, size_t col);
+		void UnexpectedEofWhileToken(std::string filename, TokenType tokenType, size_t line, size_t col);
 		void UnexpectedToken(std::string filename, std::shared_ptr<Token> locToken);
 		void UnexpectedToken(std::string filename, std::shared_ptr<Token> locToken, std::shared_ptr<Token> gotToken, TokenType expectedTokenType);
-		void MissingConstantDefinition(std::shared_ptr<Token> token);
+		void MissingConstantDefinition(std::string filename, std::shared_ptr<Token> token);
 
 	public: // Interpreter
-		void VarMismatchType(std::string name, Runtime::ValueType type, Runtime::ValueType expectedType);
+		void VarMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc);
         void VarAlreadyExists(std::string filename, std::string name, Location loc);
-		void UndefinedType(std::string name);
+		void UndefinedType(std::string filename, std::string name, Location loc);
 		void UndeclaredVariable(std::string filename, std::shared_ptr<Nodes::IdentifierNode> id);
-		void OperandMismatchType(Runtime::ValueType leftType, Runtime::ValueType rightType);
+		void OperandMismatchType(std::string filename, Runtime::ValueType leftType, Runtime::ValueType rightType, Location loc);
 		void UndeclaredFunction(std::string filename, std::shared_ptr<Nodes::IdentifierNode> id);
         // TODO:
 		// void UndeclaredFunction(std::shared_ptr<Nodes::ObjectMember> member);

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -1,90 +1,100 @@
 
 #include <cassert>
+#include <filesystem>
 #include "../include/error.h"
 
 using namespace AST;
+namespace fs = std::filesystem;
 
 namespace Prelude
 {
-    // TODO: Refactor error.cpp:
-    // 1. create separate function for logging out error location + show relative path to .tmpl file
-    // 2. provide error location in all error kinds
-    // 3. use stderr instead of stdout
-    // 4. colorize error location with grey (like this comment)
 	ErrorManager::ErrorManager() {}
 	ErrorManager::~ErrorManager() {}
 	void ErrorManager::RaiseError(std::string errorMessage)
 	{
-		std::cout << "Error: " << errorMessage
+        std::cerr << "Error: " << errorMessage
 				  << std::endl;
 		std::exit(-1);
 	}
+    void ErrorManager::LogFileLocation(std::string filename, Location loc, std::string prefix)
+    {
+        fs::path cwd = fs::current_path();
+        fs::path relative = fs::relative(filename, cwd);
+        std::cerr << "\033[90m[" << relative.string() << ":" << loc.line << ":" << loc.col << "]\033[0m \033[1;31m" << prefix << "\033[0m: ";
+    }
 	void ErrorManager::NoInputFile()
 	{
-		std::cout << "Error: No input file provided." << '\n'
+        std::cerr << "Error: No input file provided." << '\n'
 				  << std::endl;
 		std::exit(-1);
 	}
-	void ErrorManager::UnexpectedCharacter(char ch, size_t line, size_t col)
+	void ErrorManager::UnexpectedCharacter(std::string filename, char ch, size_t line, size_t col)
 	{
-		std::cout << "LexerError: Unexpected character '" << ch << "' (code: " << (int)ch << ") met at line " << line << " and " << col << " column." << std::endl;
+        LogFileLocation(filename, Location(line, col), "LexerError");
+        std::cerr << "Unexpected character '" << ch << "' (code: " << (int)ch << ") met" << std::endl;
 		std::exit(-1);
 	}
-	void ErrorManager::UnexpectedEOF(size_t line, size_t col)
+	void ErrorManager::UnexpectedEOF(std::string filename, size_t line, size_t col)
 	{
-		std::cout << "LexerError: Unexpected end of file while tokenizing at line " << line << " and " << col << " column." << std::endl;
+        LogFileLocation(filename, Location(line, col), "LexerError");
+        std::cerr << "Unexpected end of file while tokenizing" << std::endl;
 		std::exit(-1);
 	}
-	void ErrorManager::UnexpectedEofWhileToken(AST::TokenType tokenType, size_t line, size_t col)
+	void ErrorManager::UnexpectedEofWhileToken(std::string filename, AST::TokenType tokenType, size_t line, size_t col)
 	{
-		std::cout << "ParseError: Expected '" << Token::GetTokenTypeCharacter(tokenType) << "' character but got eof at line " << line << " and " << col << " column." << std::endl;
+        LogFileLocation(filename, Location(line, col), "ParseError");
+        std::cerr << "Expected '" << Token::GetTokenTypeCharacter(tokenType) << "' character but got EOF" << std::endl;
 		std::exit(-1);
 	}
 	void ErrorManager::UnexpectedToken(std::string filename, std::shared_ptr<Token> locToken)
 	{
-		std::cout << "[" << filename << ":" << locToken->GetLine() << ":" << locToken->GetColumn() << "] ";
-		std::cout << "ParseError: Unexpected token '" << Token::GetTokenTypeCharacter(locToken->GetType()) << "' token" << std::endl;
+        LogFileLocation(filename, locToken->GetLocation(), "ParseError");
+        std::cerr << "Unexpected token '" << Token::GetTokenTypeCharacter(locToken->GetType()) << "' token" << std::endl;
 		std::exit(-1);
 	}
 	void ErrorManager::UnexpectedToken(std::string filename, std::shared_ptr<Token> locToken, std::shared_ptr<Token> gotToken, TokenType expectedTokenType)
 	{
-		std::cout << "[" << filename << ":" << locToken->GetLine() << ":" << locToken->GetColumn() << "] ";
-		std::cout << "ParseError: Expected '" << Token::GetTokenTypeCharacter(expectedTokenType) << "' but got '" << Token::GetTokenTypeCharacter(gotToken->GetType()) << "'" << std::endl;
+        LogFileLocation(filename, locToken->GetLocation(), "ParseError");
+        std::cerr << "Expected '" << Token::GetTokenTypeCharacter(expectedTokenType) << "' but got '" << Token::GetTokenTypeCharacter(gotToken->GetType()) << "'" << std::endl;
 		std::exit(-1);
 	}
-	void ErrorManager::MissingConstantDefinition(std::shared_ptr<Token> token)
+	void ErrorManager::MissingConstantDefinition(std::string filename, std::shared_ptr<Token> token)
 	{
-		std::cout << "ParseError: Expected constant definition at line "
-				  << token->GetLine() << " and " << token->GetColumn() << " column but got unexpected '" << Token::GetTokenTypeCharacter(token->GetType()) << "'" << std::endl;
+        LogFileLocation(filename, token->GetLocation(), "ParseError");
+        std::cerr << "Expected constant definition "
+				  << "but got unexpected '" << Token::GetTokenTypeCharacter(token->GetType()) << "'" << std::endl;
 		std::exit(-1);
 	}
-	void ErrorManager::VarMismatchType(std::string name, Runtime::ValueType type, Runtime::ValueType expectedType)
+	void ErrorManager::VarMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc)
 	{
         // TODO: allow defining double type variable with float value (casting) and opposite direction
-		std::cout << "RuntimeError: Type mismatch for variable '" << name << "'. Expected type '" << (int)expectedType << "' but got '" << (int)type << "'" << std::endl;
+        LogFileLocation(filename, loc, "ParseError");
+        std::cerr << "Type mismatch for variable '" << name << "'. Expected type '" << (int)expectedType << "' but got '" << (int)type << "'" << std::endl;
 		std::exit(-1);
 	}
-	void ErrorManager::OperandMismatchType(Runtime::ValueType leftType, Runtime::ValueType rightType)
+	void ErrorManager::OperandMismatchType(std::string filename, Runtime::ValueType leftType, Runtime::ValueType rightType, Location loc)
 	{
-		std::cout << "RuntimeError: Mismatch type of left and right operands '" << (int)leftType << "' != '" << (int)rightType << "'" << std::endl;
+        LogFileLocation(filename, loc, "RuntimeError");
+        std::cerr << "Mismatch type of left and right operands '" << (int)leftType << "' != '" << (int)rightType << "'" << std::endl;
 		std::exit(-1);
 	}
-	void ErrorManager::UndefinedType(std::string name)
+	void ErrorManager::UndefinedType(std::string filename, std::string name, Location loc)
 	{
-		std::cout << "RuntimeError: Undefined type '" << name << "'" << std::endl;
+        LogFileLocation(filename, loc, "RuntimeError");
+        std::cerr << "Undefined type '" << name << "'" << std::endl;
 		std::exit(-1);
 	}
 	void ErrorManager::UndeclaredVariable(std::string filename, std::shared_ptr<Nodes::IdentifierNode> id)
 	{
         auto loc = id->GetLocation();
-		std::cout << "[" << filename << ":" << loc.line << ":" << loc.col << "] ";
-		std::cout << "RuntimeError: Undeclared variable '" << id->GetName() << "'" << std::endl;
+        LogFileLocation(filename, loc, "RuntimeError");
+        std::cerr << "Undeclared variable '" << id->GetName() << "'" << std::endl;
 		std::exit(-1);
 	}
     void ErrorManager::ArgMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc)
     {
-		std::cout << "[" << filename << ":" << loc.line << ":" << loc.col << "] ";
-        std::cout << "RuntimeError: Argument type ("
+        LogFileLocation(filename, loc, "RuntimeError");
+        std::cerr << "Argument type ("
             << std::to_string((int)type)
             << ") of parameter '" << name << "' doesn't match parameter type ("
             << std::to_string((int)expectedType)
@@ -94,8 +104,8 @@ namespace Prelude
 
     void ErrorManager::ReturnMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc)
     {
-		std::cout << "[" << filename << ":" << loc.line << ":" << loc.col << "] ";
-        std::cout << "RuntimeError: Return value type ("
+        LogFileLocation(filename, loc, "RuntimeError");
+        std::cerr << "Return value type ("
             << std::to_string((int)type)
             << ") of the function '" << name << "' doesn't match function's signature type ("
             << std::to_string((int)expectedType)
@@ -105,28 +115,26 @@ namespace Prelude
 
     void ErrorManager::ArgsParamsExhausted(std::string filename, std::string name, size_t argsSize, size_t paramsSize, Location loc)
     {
-		std::cout << "[" << filename << ":" << loc.line << ":" << loc.col << "] ";
-        std::cout << "RuntimeError: ";
-
+        LogFileLocation(filename, loc, "RuntimeError");
         assert(argsSize != paramsSize && "Args count is same as params count. Should be unreachable");
         
         if (argsSize < paramsSize)
         {
-            std::cout << "Exhausted args for function '" << name << "'. Needs to provide " << paramsSize << " arguments but only " << argsSize << " provided";
+            std::cerr << "Exhausted args for function '" << name << "'. Needs to provide " << paramsSize << " arguments but only " << argsSize << " provided";
         }
         else
         {
-            std::cout << "Exhausted params for function '" << name << "'. Needs to provide " << paramsSize << " arguments but " << argsSize << " provided";
+            std::cerr << "Exhausted params for function '" << name << "'. Needs to provide " << paramsSize << " arguments but " << argsSize << " provided";
         }
-        std::cout << '\n';
+        std::cerr << '\n';
 
         exit(-1);
     }
 
     void ErrorManager::UnaryOperatorNotSupported(std::string filename, std::string op, Runtime::ValueType metType, Location loc)
     {
-        std::cout << "[" << filename << ":" << loc.line << ":" << loc.col << "] ";
-        std::cout << "RuntimeError: Unary operator '" << op
+        LogFileLocation(filename, loc, "RuntimeError");
+        std::cerr << "Unary operator '" << op
             << "' is not allowed with type '" << std::to_string((int)metType) << "'" << std::endl;
         std::exit(-1);
     }
@@ -134,15 +142,15 @@ namespace Prelude
     void ErrorManager::UndeclaredFunction(std::string filename, std::shared_ptr<Nodes::IdentifierNode> id)
     {
         auto loc = id->GetLocation();
-		std::cout << "[" << filename << ":" << loc.line << ":" << loc.col << "] ";
-		std::cout << "RuntimeError: Calling undeclared function '" << id->GetName() << "'" << std::endl;
+        LogFileLocation(filename, loc, "RuntimeError");
+        std::cerr << "Calling undeclared function '" << id->GetName() << "'" << std::endl;
 		std::exit(-1);
     }
 
     // CliRunner
     void ErrorManager::NotEnoughArgs(int expected, int got, bool atLeast)
     {
-        std::cout << "ArgumentsError: Not enough additional arguments provided."
+        std::cerr << "ArgumentsError: Not enough additional arguments provided."
             << " Expected " << (atLeast ? "at least" : "") << " " << expected
             << " arguments, but got " << got
             << std::endl;
@@ -151,7 +159,7 @@ namespace Prelude
 
     void ErrorManager::InvalidArgument(std::string arg, std::string message)
     {
-        std::cout << "ArgumentsError: Invalid argument provided" << arg << "."
+        std::cerr << "ArgumentsError: Invalid argument provided" << arg << "."
             << message << std::endl;
         std::exit(1);
     }
@@ -159,22 +167,22 @@ namespace Prelude
     
     void ErrorManager::FailedOpeningFile(std::string path)
     {
-        std::cout << "FileError: Failed opening file '" << path
+        std::cerr << "FileError: Failed opening file '" << path
             << "'. No such file or directory" << std::endl;
         std::exit(1);
     }
 
     void ErrorManager::ProcedureNotFound(std::string name)
     {
-        std::cout << "ProcedureError: No procedure found with name '"
+        std::cerr << "ProcedureError: No procedure found with name '"
             << name << "'" << std::endl;
         std::exit(1);
     }
 
     void ErrorManager::VarAlreadyExists(std::string filename, std::string name, Location loc)
     {
-		std::cout << "[" << filename << ":" << loc.line << ":" << loc.col << "] ";
-        std::cout << "RuntimeError: Cannot redeclare already existing variable '"
+        LogFileLocation(filename, loc, "RuntimeError");
+        std::cerr << "Cannot redeclare already existing variable '"
             << name << "'" << std::endl;
         std::exit(-1);
     }

--- a/tmpl-script/src/interpreter/expr.cpp
+++ b/tmpl-script/src/interpreter/expr.cpp
@@ -83,7 +83,7 @@ namespace Runtime
 		if (left->GetType() != right->GetType() && left->GetType() != ValueType::Null && right->GetType() != ValueType::Null)
 		{
 			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-			errorManager.OperandMismatchType(left->GetType(), right->GetType());
+			errorManager.OperandMismatchType(GetFilename(), left->GetType(), right->GetType(), condition->GetLocation());
 			return nullptr;
 		}
 

--- a/tmpl-script/src/interpreter/type.cpp
+++ b/tmpl-script/src/interpreter/type.cpp
@@ -29,7 +29,7 @@ namespace Runtime
 			else
 			{
 				Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-				errorManager.UndefinedType(id->GetName());
+				errorManager.UndefinedType(GetFilename(), id->GetName(), id->GetLocation());
 			}
 		}
 		else

--- a/tmpl-script/src/interpreter/var_decl.cpp
+++ b/tmpl-script/src/interpreter/var_decl.cpp
@@ -14,7 +14,7 @@ namespace Runtime
 		if (varType != varValue->GetType())
 		{
 			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-			errorManager.VarMismatchType(varName, varValue->GetType(), varType);
+			errorManager.VarMismatchType(GetFilename(), varName, varValue->GetType(), varType, varDecl->GetLocation());
 			return;
 		}
 

--- a/tmpl-script/src/lexer.cpp
+++ b/tmpl-script/src/lexer.cpp
@@ -201,7 +201,7 @@ namespace AST
 				break;
 			default:
 				Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-				errorManager.UnexpectedCharacter(ch, m_line, m_col);
+				errorManager.UnexpectedCharacter(GetFilename(), ch, m_line, m_col);
 				break;
 			}
 
@@ -239,7 +239,7 @@ namespace AST
 			else if (id->empty())
 			{
 				Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-				errorManager.UnexpectedEOF(m_line, m_col);
+				errorManager.UnexpectedEOF(GetFilename(), m_line, m_col);
 				break;
 			}
 			else
@@ -337,7 +337,7 @@ namespace AST
 				if (already_met_point)
 				{
 					Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-					errorManager.UnexpectedCharacter(ch, m_line, m_col);
+					errorManager.UnexpectedCharacter(GetFilename(), ch, m_line, m_col);
 					break;
 				}
 				else
@@ -351,7 +351,7 @@ namespace AST
 			else if (number->empty())
 			{
 				Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-				errorManager.UnexpectedEOF(m_line, m_col);
+				errorManager.UnexpectedEOF(GetFilename(), m_line, m_col);
 				break;
 			}
 			else

--- a/tmpl-script/src/parser.cpp
+++ b/tmpl-script/src/parser.cpp
@@ -21,7 +21,7 @@ namespace AST
 			if (m_lexer->GetToken()->GetType() == TokenType::_EOF)
 			{
 				auto token = m_lexer->GetToken();
-				GetErrorManager().UnexpectedEofWhileToken(type, token->GetLine(), token->GetColumn());
+				GetErrorManager().UnexpectedEofWhileToken(GetFilename(), type, token->GetLine(), token->GetColumn());
 			}
 			else
 			{
@@ -83,7 +83,7 @@ namespace AST
             if (tokenType == TokenType::_EOF)
             {
                 Prelude::ErrorManager& manager = GetErrorManager();
-                manager.UnexpectedEOF(token->GetLine(), token->GetColumn());
+                manager.UnexpectedEOF(GetFilename(), token->GetLine(), token->GetColumn());
                 return nullptr;
             }
             Eat(TokenType::At);

--- a/tmpl-script/src/parser/statement.cpp
+++ b/tmpl-script/src/parser/statement.cpp
@@ -157,7 +157,7 @@ namespace AST
 		else if (!editable)
 		{
 			Prelude::ErrorManager &manager = GetErrorManager();
-			manager.MissingConstantDefinition(m_lexer->GetToken());
+			manager.MissingConstantDefinition(GetFilename(), m_lexer->GetToken());
 			return nullptr;
 		}
 


### PR DESCRIPTION
## Refactor of ErrorManager class

### TODOs completed:

- Create separate function for logging out error location + show relative path to `.tmpl` file
- Provide error location in all error kinds
- Use `stderr` instead of `stdout`
- Colorize error location with grey (like this comment)