### PR TITLE
Functions Encapsulation

### DIFF
--- a/example/.tmpl/dummstd.tmpl
+++ b/example/.tmpl/dummstd.tmpl
@@ -1,0 +1,9 @@
+
+fn add_ints(int a, int b) : int {
+    return a + b;
+}
+
+export fn increment(int num) : int {
+    return add_ints(num, 1);
+}
+

--- a/example/.tmpl/main.tmpl
+++ b/example/.tmpl/main.tmpl
@@ -1,0 +1,7 @@
+@require"dummstd"
+
+->main {
+    return add_ints(25, 25);
+    return increment(10);
+}
+

--- a/example/.tmpl/main.tmpl
+++ b/example/.tmpl/main.tmpl
@@ -1,7 +1,6 @@
 @require"dummstd"
 
 ->main {
-    return add_ints(25, 25);
     return increment(10);
 }
 

--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -38,6 +38,7 @@ namespace Prelude
     
     private:
         void LogFileLocation(std::string filename, Location loc, std::string prefix);
+        void LogFileLocation(std::string filename, Location loc);
         void LogPrefix(std::string prefix);
 
 	public: // Lexer (Tokenizer)
@@ -51,21 +52,23 @@ namespace Prelude
 		void MissingConstantDefinition(std::string filename, std::shared_ptr<Token> token);
 
 	public: // Interpreter
-		void VarMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc, std::string prefix);
-        void VarAlreadyExists(std::string filename, std::string name, Location loc, std::string prefix);
-		void UndefinedType(std::string filename, std::string name, Location loc, std::string prefix);
-		void UndeclaredVariable(std::string filename, std::shared_ptr<Nodes::IdentifierNode> id, std::string prefix);
-		void OperandMismatchType(std::string filename, Runtime::ValueType leftType, Runtime::ValueType rightType, Location loc, std::string prefix);
-		void UndeclaredFunction(std::string filename, std::shared_ptr<Nodes::IdentifierNode> id, std::string prefix);
         // TODO:
 		// void UndeclaredFunction(std::shared_ptr<Nodes::ObjectMember> member);
-		void ArgMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc, std::string prefix);
 		void ReturnMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc);
-        void ArgsParamsExhausted(std::string filename, std::string name, size_t argsSize, size_t paramsSize, Location loc, std::string prefix);
         void UnaryOperatorNotSupported(std::string filename, std::string op, Runtime::ValueType metType, Location loc);
     public: // TypeChecker
         void UnexpectedReturnType(std::string filename, Runtime::ValueType expected, Runtime::ValueType gotType, Location loc);
         void TypeMismatch(std::string filename, Runtime::ValueType left, Runtime::ValueType right, Location loc);
+    public: // TypeChecker + Interpreter
+        void PrivateFunctionError(std::string filename, std::string fnName, std::string fnModule, Location loc, Location mLoc, std::string prefix);
+        void ArgsParamsExhausted(std::string filename, std::string name, size_t argsSize, size_t paramsSize, Location loc, std::string prefix);
+		void ArgMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc, std::string prefix);
+		void UndeclaredFunction(std::string filename, std::shared_ptr<Nodes::IdentifierNode> id, std::string prefix);
+		void OperandMismatchType(std::string filename, Runtime::ValueType leftType, Runtime::ValueType rightType, Location loc, std::string prefix);
+		void UndeclaredVariable(std::string filename, std::shared_ptr<Nodes::IdentifierNode> id, std::string prefix);
+		void UndefinedType(std::string filename, std::string name, Location loc, std::string prefix);
+		void VarMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc, std::string prefix);
+        void VarAlreadyExists(std::string filename, std::string name, Location loc, std::string prefix);
     public: // CliRunner
         void NotEnoughArgs(int expected, int got, bool atLeast);
         void InvalidArgument(std::string arg, std::string message);

--- a/tmpl-script/include/interpreter.h
+++ b/tmpl-script/include/interpreter.h
@@ -62,7 +62,7 @@ namespace Runtime
 	private:
 		void EvaluateVariableDeclaration(std::shared_ptr<VarDeclaration> varDecl);
 		void EvaluateProcedureDeclaration(std::shared_ptr<ProcedureDeclaration> procDecl);
-        void EvaluateFunctionDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl);
+        void EvaluateFunctionDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported);
         void EvaluateExportStatement(std::shared_ptr<ExportStatement> exportStmt);
 
     private:

--- a/tmpl-script/include/interpreter/environment.h
+++ b/tmpl-script/include/interpreter/environment.h
@@ -67,23 +67,34 @@ namespace Runtime
 		std::shared_ptr<Node> m_body;
         std::vector<std::shared_ptr<FnParam>> m_params;
         ValueType m_ret_type;
+
+        std::string m_module_name;
+        bool m_exported;
+        Location m_loc;
     private:
         size_t m_index;
 
 	public:
-		Fn(std::shared_ptr<Node> body, ValueType retType)
-			: m_body(body), m_ret_type(retType), m_params(std::vector<std::shared_ptr<FnParam>>()), m_index(0) {}
+		Fn(std::shared_ptr<Node> body, ValueType retType, std::string module, bool exported, Location loc)
+			: m_body(body),
+            m_ret_type(retType),
+            m_params(std::vector<std::shared_ptr<FnParam>>()),
+            m_index(0),
+            m_module_name(module), m_exported(exported), m_loc(loc) {}
 
     public:
         void AddParam(std::shared_ptr<FnParam> param) { m_params.push_back(param); }
 
 	public:
-		inline std::shared_ptr<Node> GetBody() { return m_body; }
-        inline bool HasParams() { return m_index < m_params.size(); }
+		inline std::shared_ptr<Node> GetBody() const { return m_body; }
+        inline bool HasParams() const { return m_index < m_params.size(); }
         inline std::shared_ptr<FnParam> GetNextParam() { return m_params[m_index++]; }
-        inline size_t GetParamsSize() { return m_params.size(); }
-        inline size_t GetParamsIndex() { return m_index; }
-        inline ValueType GetReturnType() { return m_ret_type; }
+        inline size_t GetParamsSize() const { return m_params.size(); }
+        inline size_t GetParamsIndex() const { return m_index; }
+        inline ValueType GetReturnType() const { return m_ret_type; }
+        inline std::string GetModuleName() const { return m_module_name; }
+        inline bool IsExported() const { return m_exported; }
+        inline Location GetLocation() const { return m_loc; }
 
 		friend std::ostream &operator<<(std::ostream &stream, const Fn &fn)
 		{

--- a/tmpl-script/include/typechecker.h
+++ b/tmpl-script/include/typechecker.h
@@ -38,23 +38,34 @@ namespace Runtime
 	private:
         std::vector<std::shared_ptr<FnParam>> m_params;
         ValueType m_ret_type;
+        std::string m_module_name;
+        bool m_exported;
+        Location m_loc;
     private:
         size_t m_index;
 
 	public:
-		TypeFn(ValueType retType)
-			: m_ret_type(retType), m_params(std::vector<std::shared_ptr<FnParam>>()), m_index(0) {}
+		TypeFn(ValueType retType, std::string module, bool exported, Location loc)
+			: m_ret_type(retType),
+            m_params(std::vector<std::shared_ptr<FnParam>>()),
+            m_index(0),
+            m_module_name(module),
+            m_exported(exported),
+            m_loc(loc) {}
 
     public:
         void AddParam(std::shared_ptr<FnParam> param) { m_params.push_back(param); }
 
 	public:
         void ResetIterator() { m_index = 0; }
-        inline bool HasParams() { return m_index < m_params.size(); }
+        inline bool HasParams() const { return m_index < m_params.size(); }
         inline std::shared_ptr<FnParam> GetNextParam() { return m_params[m_index++]; }
-        inline size_t GetParamsSize() { return m_params.size(); }
-        inline size_t GetParamsIndex() { return m_index; }
-        inline ValueType GetReturnType() { return m_ret_type; }
+        inline size_t GetParamsSize() const { return m_params.size(); }
+        inline size_t GetParamsIndex() const { return m_index; }
+        inline ValueType GetReturnType() const { return m_ret_type; }
+        inline std::string GetModuleName() const { return m_module_name; }
+        inline bool IsExported() const { return m_exported; }
+        inline Location GetLocation() const { return m_loc; }
 	};
 
     class TypeChecker
@@ -88,7 +99,7 @@ namespace Runtime
 
     private:
         void HandleVarDeclaration(std::shared_ptr<VarDeclaration> varDecl);
-        void HandleFnDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl);
+        void HandleFnDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported);
         void HandleModule(std::shared_ptr<ProgramNode> program);
         void HandleExportStatement(std::shared_ptr<ExportStatement> exportStmt);
 

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -25,6 +25,13 @@ namespace Prelude
         std::cerr << "\033[90m[" << relative.string() << ":" << loc.line << ":" << loc.col << "]\033[0m \033[1;31m" << prefix << "\033[0m: ";
     }
 
+    void ErrorManager::LogFileLocation(std::string filename, Location loc)
+    {
+        fs::path cwd = fs::current_path();
+        fs::path relative = fs::relative(filename, cwd);
+        std::cerr << "(\033[90m" << relative.string() << ":" << loc.line << ":" << loc.col << "\033[0m)";
+    }
+
     void ErrorManager::LogPrefix(std::string prefix)
     {
         std::cerr << "\033[1;31m" << prefix << "\033[0m: ";
@@ -214,6 +221,16 @@ namespace Prelude
         LogFileLocation(filename, loc, prefix);
         std::cerr << "Cannot redeclare already existing variable '"
             << name << "'" << std::endl;
+        if (prefix != "TypeError") std::exit(-1);
+    }
+
+    void ErrorManager::PrivateFunctionError(std::string filename, std::string fnName, std::string fnModule, Location loc, Location mLoc, std::string prefix)
+    {
+        LogFileLocation(filename, loc, prefix);
+        std::cerr << "Cannot call a private function '" << fnName
+            << "' outside of it's module ";
+        LogFileLocation(fnModule, mLoc);
+        std::cout << std::endl;
         if (prefix != "TypeError") std::exit(-1);
     }
 

--- a/tmpl-script/src/interpreter.cpp
+++ b/tmpl-script/src/interpreter.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include "../include/interpreter.h"
 #include "../include/error.h"
+#include "include/node/function.h"
 #include "include/node/statement.h"
 
 namespace Runtime
@@ -45,6 +46,9 @@ namespace Runtime
                     break;
                 case NodeType::Export:
                     EvaluateExportStatement(std::dynamic_pointer_cast<ExportStatement>(stmt));
+                    break;
+                case NodeType::FnDecl:
+                    EvaluateFunctionDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt));
                     break;
                 default:
                     {

--- a/tmpl-script/src/interpreter.cpp
+++ b/tmpl-script/src/interpreter.cpp
@@ -20,7 +20,7 @@ namespace Runtime
                     ImportModule(std::dynamic_pointer_cast<RequireMacro>(stmt));
                     break;
                 case NodeType::FnDecl:
-                    EvaluateFunctionDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt));
+                    EvaluateFunctionDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt), false);
                     break;
                 case NodeType::ProcedureDecl:
                     EvaluateProcedureDeclaration(std::dynamic_pointer_cast<ProcedureDeclaration>(stmt));
@@ -48,7 +48,7 @@ namespace Runtime
                     EvaluateExportStatement(std::dynamic_pointer_cast<ExportStatement>(stmt));
                     break;
                 case NodeType::FnDecl:
-                    EvaluateFunctionDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt));
+                    EvaluateFunctionDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt), true);
                     break;
                 default:
                     {

--- a/tmpl-script/src/interpreter/fn_call.cpp
+++ b/tmpl-script/src/interpreter/fn_call.cpp
@@ -27,6 +27,13 @@ namespace Runtime
 
             std::shared_ptr<Fn> fn = m_functions->LookUp(fnName);
 
+            if (GetFilename() != fn->GetModuleName() && !fn->IsExported())
+            {
+                Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+                errorManager.PrivateFunctionError(GetFilename(), fnName, fn->GetModuleName(), callee->GetLocation(), fn->GetLocation(), "RuntimeError");
+                return nullptr;
+            }
+
             std::shared_ptr<Environment<Variable>> currentScope = m_variables;
             std::shared_ptr<Environment<Variable>> variables = std::make_shared<Environment<Variable>>(m_variables);
 

--- a/tmpl-script/src/interpreter/fn_decl.cpp
+++ b/tmpl-script/src/interpreter/fn_decl.cpp
@@ -9,13 +9,13 @@ namespace Runtime
 {
     using namespace AST::Nodes;
 
-    void Interpreter::EvaluateFunctionDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl)
+    void Interpreter::EvaluateFunctionDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported)
     {
         std::string name = fnDecl->GetName();
         std::shared_ptr<Statements::StatementsBody> body = fnDecl->GetBody();
         ValueType retType = TypeChecker::EvaluateType(GetFilename(), fnDecl->GetReturnType());
 
-        std::shared_ptr<Fn> fn = std::make_shared<Fn>(body, retType);
+        std::shared_ptr<Fn> fn = std::make_shared<Fn>(body, retType, GetFilename(), exported, fnDecl->GetLocation());
 
         while (fnDecl->HasParams())
         {

--- a/tmpl-script/src/interpreter/import.cpp
+++ b/tmpl-script/src/interpreter/import.cpp
@@ -17,7 +17,7 @@ namespace Runtime
         switch(target->GetType())
         {
            case NodeType::FnDecl:
-                EvaluateFunctionDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(target));
+                EvaluateFunctionDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(target), true);
                 break;
             case NodeType::VarDecl:
                 EvaluateVariableDeclaration(std::dynamic_pointer_cast<VarDeclaration>(target));

--- a/tmpl-script/src/typechecker.cpp
+++ b/tmpl-script/src/typechecker.cpp
@@ -104,7 +104,7 @@ namespace Runtime
                     RunModuleChecker(std::dynamic_pointer_cast<RequireMacro>(stmt));
                     break;
                 case NodeType::FnDecl:
-                    HandleFnDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt));
+                    HandleFnDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt), false);
                     break;
                 // TODO: add require, export support
                 default:

--- a/tmpl-script/src/typechecker/fn_call.cpp
+++ b/tmpl-script/src/typechecker/fn_call.cpp
@@ -27,6 +27,14 @@ namespace Runtime
 
         std::shared_ptr<TypeFn> fn = m_functions->LookUp(fnName);
 
+        if (GetFilename() != fn->GetModuleName() && !fn->IsExported())
+        {
+            Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+            errorManager.PrivateFunctionError(GetFilename(), fnName, fn->GetModuleName(), callee->GetLocation(), fn->GetLocation(), "TypeError");
+            ReportError();
+            return ValueType::Null;
+        }
+
         auto args = fnCall->GetArgs();
 
         if (fn->GetParamsSize() != args->size())

--- a/tmpl-script/src/typechecker/fn_decl.cpp
+++ b/tmpl-script/src/typechecker/fn_decl.cpp
@@ -6,14 +6,14 @@ namespace Runtime
 {
     using namespace AST::Nodes;
 
-    void TypeChecker::HandleFnDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl)
+    void TypeChecker::HandleFnDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported)
     {
         std::shared_ptr<Statements::StatementsBody> body = fnDecl->GetBody();
         ValueType retType = EvaluateType(GetFilename(), fnDecl->GetReturnType());
 
         std::string name = fnDecl->GetName();
 
-        std::shared_ptr<TypeFn> fn = std::make_shared<TypeFn>(retType);
+        std::shared_ptr<TypeFn> fn = std::make_shared<TypeFn>(retType, GetFilename(), exported, fnDecl->GetLocation());
 
         auto currentScope = m_variables;
         auto variables = std::make_shared<Environment<TypeVariable>>(m_variables);

--- a/tmpl-script/src/typechecker/module.cpp
+++ b/tmpl-script/src/typechecker/module.cpp
@@ -47,7 +47,7 @@ namespace Runtime
         switch(target->GetType())
         {
            case NodeType::FnDecl:
-                HandleFnDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(target));
+                HandleFnDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(target), true);
                 break;
             case NodeType::VarDecl:
                 HandleVarDeclaration(std::dynamic_pointer_cast<VarDeclaration>(target));
@@ -72,7 +72,7 @@ namespace Runtime
                     HandleExportStatement(std::dynamic_pointer_cast<ExportStatement>(stmt));
                     break;
                 case NodeType::FnDecl:
-                    HandleFnDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt));
+                    HandleFnDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt), false);
                     break;
                 default:
                     {

--- a/tmpl-script/src/typechecker/module.cpp
+++ b/tmpl-script/src/typechecker/module.cpp
@@ -1,6 +1,8 @@
 
 #include <filesystem>
+#include <memory>
 #include "../../include/typechecker.h"
+#include "include/node/function.h"
 
 namespace fs = std::filesystem;
 
@@ -68,6 +70,9 @@ namespace Runtime
                     break;
                 case NodeType::Export:
                     HandleExportStatement(std::dynamic_pointer_cast<ExportStatement>(stmt));
+                    break;
+                case NodeType::FnDecl:
+                    HandleFnDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt));
                     break;
                 default:
                     {


### PR DESCRIPTION
Functions in `tmpl`, that are declared inside of a module, will be only accessible via that module. It means you cannot use functions declared in a module and not exported inside your code.

### Example

`.tmpl/dummstd.tmpl`:
```
fn add_ints(int a, int b) : int {
    return a + b;
}

export fn increment(int num) : int {
    return add_ints(num, 1);
}
```

`.tmpl/main.tmpl`:
```
@require"dummstd"

->main {
    return add_ints(25, 25); # cannot be used here
    return increment(10);
}
```

#### Output after executing `tmpl main`:
```
[.tmpl/main.tmpl:4:19] TypeError: Cannot call a private function 'add_ints' outside of it's module (.tmpl/dummstd.tmpl:2:2)
PreLaunchError: Found 1 type errors. Exiting...
```