### PR TITLE
Custom Type Defintions

### DIFF
--- a/TYPEDF.md
+++ b/TYPEDF.md
@@ -39,3 +39,60 @@ After that you can define a variable with your custom type
     # use your type...
 }
 ```
+
+## Type Casting
+
+In order to cast one type to another you need to use following syntax
+
+```
+->main {
+    var float PI = 3.1415;
+    var int PI_int = (int)PI;
+    println(PI_int.tostring()); # expected "3"
+}
+```
+
+Going further with above example, you can do down-casting any time for any custom defined type. Down-casting is a casting of the type to it's parent type (base type).
+
+Here's an example of down-casting
+
+```
+typedf Integer = int;
+
+fn @construct Integer(int value) : Integer {
+    return value;
+}
+
+->main {
+    var Integer test = new Integer(50);
+    var int native = (int)test;
+    println(native.tostring()); # expected "50"
+}
+```
+
+In above example down-casting to `int` will only work if `Integer` inherits from `int`.
+
+## Custom Type Casters
+
+If you want your type to be casted to another type, for example our `Integer` to `string`, then you can implement custom caster for your type
+
+Here is an example of creating custom type caster for your own type
+
+```
+typedf Integer = int;
+
+fn @construct Integer(int value) : Integer {
+    return value;
+}
+
+fn @cast(Integer) -> string {
+    return ((int)self).tostring();
+}
+
+->main {
+    var Integer test = new Integer(100);
+    var string data = (string)test;
+    println(data); # expected: "100"
+}
+```
+

--- a/TYPEDF.md
+++ b/TYPEDF.md
@@ -1,0 +1,41 @@
+A new feature that allows users define their custom types and use them. Custom types have a lot of features like custom constructors, casters and type inheritance.
+
+## Example of Defining a Custom Type
+
+In order to define custom type, you need to decide what base type you will use for your type. 
+
+### Built-In Types (at the moment)
+1. int
+2. float
+3. double
+4. bool
+5. string
+
+After you decided which type you want to use, you can define your type using following syntax:
+
+```
+typedf Integer = int;
+```
+
+In the above example we've defined custom type named `Integer` that inherits from `int`. That means that `int` is now the base type of `Integer`
+
+## Using Your Custom Type
+
+After type definition you should declare type's constructor in order to define variables within that type.
+
+```
+fn @construct Integer(int value) : Integer {
+    return value;
+}
+```
+
+Your constructor should return your type's base type. In above example the constructor of `Integer` should return `int`, because `int` was specified as base type that `Integer` inherits from.
+
+After that you can define a variable with your custom type
+
+```
+->main {
+    var Integer test = new Integer(50);
+    # use your type...
+}
+```

--- a/example/.tmpl/cast.tmpl
+++ b/example/.tmpl/cast.tmpl
@@ -6,7 +6,9 @@ fn @cast(int) : float {
 }
 
 ->main {
-    var Integer test = new Integer(50);
-    return (string)test;
+    var Integer a = new Integer(50);
+    var Integer b = new Integer(100);
+    var Integer res = a + b;
+    return (string)res;
 }
 

--- a/example/.tmpl/cast.tmpl
+++ b/example/.tmpl/cast.tmpl
@@ -5,6 +5,11 @@ fn @construct Integer(int value) : Integer {
     return value;
 }
 
+fn @cast(int) : float {
+    # Dummy
+    return 3.1415;
+}
+
 fn @cast(Integer) : float {
     return (float)(int)self;
 }
@@ -17,6 +22,7 @@ fn Integer.getInt() : int {
     var int expr = (5 - 2) * 5;
     var int nExpr = -expr;
     var Integer test = new Integer(nExpr);
-    return test.getInt();
+    var float testF = (float)test;
+    return testF;
 }
 

--- a/example/.tmpl/cast.tmpl
+++ b/example/.tmpl/cast.tmpl
@@ -5,9 +5,14 @@ fn @construct Integer(int value) : Integer {
     return value;
 }
 
+fn Integer.getInt() : int {
+    return (int)self;
+}
+
 ->main {
     var int expr = (5 - 2) * 5;
-    var Integer test = new Integer(50);
-    return (int)test;
+    var int nExpr = -expr;
+    var Integer test = new Integer(nExpr);
+    return test.getInt();
 }
 

--- a/example/.tmpl/cast.tmpl
+++ b/example/.tmpl/cast.tmpl
@@ -1,28 +1,12 @@
-
-typedf Integer = int;
-
-fn @construct Integer(int value) : Integer {
-    return value;
-}
+@require"integer"
 
 fn @cast(int) : float {
     # Dummy
     return 3.1415;
 }
 
-fn @cast(Integer) : float {
-    return (float)(int)self;
-}
-
-fn Integer.getInt() : int {
-    return (int)self;
-}
-
 ->main {
-    var int expr = (5 - 2) * 5;
-    var int nExpr = -expr;
-    var Integer test = new Integer(nExpr);
-    var float testF = (float)test;
-    return testF;
+    var Integer test = new Integer(50);
+    return (string)test;
 }
 

--- a/example/.tmpl/cast.tmpl
+++ b/example/.tmpl/cast.tmpl
@@ -1,0 +1,13 @@
+
+typedf Integer = int;
+
+fn @construct Integer(int value) : Integer {
+    return value;
+}
+
+->main {
+    var int expr = (5 - 2) * 5;
+    var Integer test = new Integer(50);
+    return (int)test;
+}
+

--- a/example/.tmpl/cast.tmpl
+++ b/example/.tmpl/cast.tmpl
@@ -5,6 +5,10 @@ fn @construct Integer(int value) : Integer {
     return value;
 }
 
+fn @cast(Integer) : float {
+    return (float)(int)self;
+}
+
 fn Integer.getInt() : int {
     return (int)self;
 }

--- a/example/.tmpl/fn.tmpl
+++ b/example/.tmpl/fn.tmpl
@@ -3,6 +3,6 @@ fn params(int num, string msg) : float {
 }
 
 ->params {
-    var int res = params(123.5, "Hi everyone!", 864);
+    var float res = params(123, "Hi everyone!");
     return res;
 }

--- a/example/.tmpl/integer.tmpl
+++ b/example/.tmpl/integer.tmpl
@@ -1,0 +1,12 @@
+@require"std/convert"
+
+export typedf Integer = int;
+
+export fn @construct Integer(int value) : Integer {
+    return value;
+}
+
+export fn @cast(Integer) : string {
+    return ((int)self).tostring();
+}
+

--- a/example/.tmpl/main.tmpl
+++ b/example/.tmpl/main.tmpl
@@ -17,13 +17,13 @@ fn factorial(int n) : int {
     } else {
         println("is_good is false!");
     }
-    return PI + itof(factor);
+    return PI + factor.tofloat();
 }
 
 ->fact {
     var int num = 7;
     var int res = factorial(7);
-    println("Factorial of " + itos(num) + " is " + itos(res));
+    println("Factorial of " + itos(num) + " is " + res.tostring());
     return res;
 }
 
@@ -38,6 +38,6 @@ fn factorial(int n) : int {
     var string msg = "Hello, World!";
     print("Message to get length of: ");
     println(msg);
-    return strlen(msg);
+    return msg.len();
 }
 

--- a/example/.tmpl/typdfn.tmpl
+++ b/example/.tmpl/typdfn.tmpl
@@ -2,12 +2,20 @@
 
 typedf Integer = int;
 
-fn @construct Integer() : Integer {
-    return self;
+fn @construct Integer(int initialValue) : Integer {
+    return initialValue;
+}
+
+typedf Number = Integer;
+
+fn @construct Number(int initialValue) : Number {
+    var Integer integerVal = new Integer(initialValue);
+    return integerVal;
 }
 
 ->main {
-    var Integer test = new Integer(50);
+    var Number num = new Number(100);
+    println(num);
     println("Hello, World!");
 }
 

--- a/example/.tmpl/typdfn.tmpl
+++ b/example/.tmpl/typdfn.tmpl
@@ -1,0 +1,8 @@
+@require"std/io"
+
+typedf Integer = int;
+
+->main {
+    println("Hello, World!");
+}
+

--- a/example/.tmpl/typdfn.tmpl
+++ b/example/.tmpl/typdfn.tmpl
@@ -2,7 +2,12 @@
 
 typedf Integer = int;
 
+fn @construct Integer() : Integer {
+    return self;
+}
+
 ->main {
+    var Integer test = new Integer(50);
     println("Hello, World!");
 }
 

--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -7,6 +7,7 @@
 #include "token.h"
 #include "interpreter/value.h"
 #include "node/identifier.h"
+#include "node/type.h"
 
 namespace Prelude
 {
@@ -60,6 +61,7 @@ namespace Prelude
         void TypeMismatch(std::string filename, Runtime::PValType left, Runtime::PValType right, AST::Location loc);
         void TypeDoesNotExist(std::string filename, Runtime::PValType typ, AST::Location loc, std::string prefix);
         void TypeCastNotPossible(std::string filename, Runtime::PValType from, Runtime::PValType to, AST::Location loc, std::string prefix);
+        void TypeRedeclaration(std::string filename, std::shared_ptr<AST::Nodes::TypeTemplateNode> typeNode, std::string prefix);
     public: // TypeChecker + Interpreter
         void PrivateFunctionError(std::string filename, std::string fnName, std::string fnModule, AST::Location loc, AST::Location mLoc, std::string prefix);
         void ArgsParamsExhausted(std::string filename, std::string name, size_t argsSize, size_t paramsSize, AST::Location loc, std::string prefix);

--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -65,6 +65,7 @@ namespace Prelude
         void TypeCastNotPossible(std::string filename, Runtime::PValType from, Runtime::PValType to, AST::Location loc, std::string prefix);
         void TypeRedeclaration(std::string filename, std::shared_ptr<AST::Nodes::TypeTemplateNode> typeNode, std::string prefix);
         void TypeConstructorRedeclaration(std::string filename, std::string typeName, AST::Location loc, std::string prefix);
+        void TypeCastRedeclaration(std::string filename, std::string typeName, Runtime::PValType castType, AST::Location loc, std::string prefix);
         void TypeConstructorDoesNotExist(std::string filename, Runtime::PValType targetTyp, AST::Location loc, std::string prefix);
     public: // TypeChecker + Interpreter
         void PrivateFunctionError(std::string filename, std::string fnName, std::string fnModule, AST::Location loc, AST::Location mLoc, std::string prefix);

--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -67,7 +67,7 @@ namespace Prelude
 		void OperandMismatchType(std::string filename, Runtime::ValueType leftType, Runtime::ValueType rightType, AST::Location loc, std::string prefix);
 		void UndeclaredVariable(std::string filename, std::shared_ptr<AST::Nodes::IdentifierNode> id, std::string prefix);
 		void UndefinedType(std::string filename, std::string name, AST::Location loc, std::string prefix);
-		void VarMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, AST::Location loc, std::string prefix);
+		void VarMismatchType(std::string filename, std::string name, Runtime::PValType type, Runtime::PValType expectedType, AST::Location loc, std::string prefix);
         void VarAlreadyExists(std::string filename, std::string name, AST::Location loc, std::string prefix);
         void FunctionRedeclaration(std::string filename, std::string name, AST::Location loc, std::string declFilename, AST::Location declLoc, std::string prefix);
     public: // CliRunner

--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -61,8 +61,11 @@ namespace Prelude
         void UnexpectedReturnType(std::string filename, Runtime::PValType expected, Runtime::PValType gotType, AST::Location loc);
         void TypeMismatch(std::string filename, Runtime::PValType left, Runtime::PValType right, AST::Location loc);
         void TypeDoesNotExist(std::string filename, Runtime::PValType typ, AST::Location loc, std::string prefix);
+        void TypeDoesNotExist(std::string filename, std::string typName, AST::Location loc, std::string prefix);
         void TypeCastNotPossible(std::string filename, Runtime::PValType from, Runtime::PValType to, AST::Location loc, std::string prefix);
         void TypeRedeclaration(std::string filename, std::shared_ptr<AST::Nodes::TypeTemplateNode> typeNode, std::string prefix);
+        void TypeConstructorRedeclaration(std::string filename, std::string typeName, AST::Location loc, std::string prefix);
+        void TypeConstructorDoesNotExist(std::string filename, Runtime::PValType targetTyp, AST::Location loc, std::string prefix);
     public: // TypeChecker + Interpreter
         void PrivateFunctionError(std::string filename, std::string fnName, std::string fnModule, AST::Location loc, AST::Location mLoc, std::string prefix);
         void ArgsParamsExhausted(std::string filename, std::string name, size_t argsSize, size_t paramsSize, AST::Location loc, std::string prefix);

--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -67,6 +67,7 @@ namespace Prelude
         void TypeConstructorRedeclaration(std::string filename, std::string typeName, AST::Location loc, std::string prefix);
         void TypeCastRedeclaration(std::string filename, std::string typeName, Runtime::PValType castType, AST::Location loc, std::string prefix);
         void TypeConstructorDoesNotExist(std::string filename, Runtime::PValType targetTyp, AST::Location loc, std::string prefix);
+        void PrivateTypeError(std::string filename, std::string typName, std::string typModule, AST::Location loc, AST::Location mLoc, std::string prefix);
     public: // TypeChecker + Interpreter
         void PrivateFunctionError(std::string filename, std::string fnName, std::string fnModule, AST::Location loc, AST::Location mLoc, std::string prefix);
         void ArgsParamsExhausted(std::string filename, std::string name, size_t argsSize, size_t paramsSize, AST::Location loc, std::string prefix);

--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -58,6 +58,8 @@ namespace Prelude
     public: // TypeChecker
         void UnexpectedReturnType(std::string filename, Runtime::ValueType expected, Runtime::ValueType gotType, AST::Location loc);
         void TypeMismatch(std::string filename, Runtime::ValueType left, Runtime::ValueType right, AST::Location loc);
+        void TypeDoesNotExist(std::string filename, Runtime::PValType typ, std::string prefix);
+        void TypeCastNotPossible(std::string filename, Runtime::PValType from, Runtime::PValType to, std::string prefix);
     public: // TypeChecker + Interpreter
         void PrivateFunctionError(std::string filename, std::string fnName, std::string fnModule, AST::Location loc, AST::Location mLoc, std::string prefix);
         void ArgsParamsExhausted(std::string filename, std::string name, size_t argsSize, size_t paramsSize, AST::Location loc, std::string prefix);

--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -53,8 +53,8 @@ namespace Prelude
 	public: // Interpreter
         // TODO:
 		// void UndeclaredFunction(std::shared_ptr<Nodes::ObjectMember> member);
-		void ReturnMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, AST::Location loc);
-        void UnaryOperatorNotSupported(std::string filename, std::string op, Runtime::ValueType metType, AST::Location loc);
+		void ReturnMismatchType(std::string filename, std::string name, Runtime::PValType type, Runtime::PValType expectedType, AST::Location loc);
+        void UnaryOperatorNotSupported(std::string filename, std::string op, Runtime::PValType metType, AST::Location loc);
     public: // TypeChecker
         void UnexpectedReturnType(std::string filename, Runtime::PValType expected, Runtime::PValType gotType, AST::Location loc);
         void TypeMismatch(std::string filename, Runtime::PValType left, Runtime::PValType right, AST::Location loc);

--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -50,6 +50,7 @@ namespace Prelude
 		void UnexpectedToken(std::string filename, std::shared_ptr<AST::Token> locToken);
 		void UnexpectedToken(std::string filename, std::shared_ptr<AST::Token> locToken, std::shared_ptr<AST::Token> gotToken, AST::TokenType expectedTokenType);
 		void MissingConstantDefinition(std::string filename, std::shared_ptr<AST::Token> token);
+        void UnexpectedFnModifier(std::string filename, std::shared_ptr<AST::Token> gotToken, AST::Location loc);
 
 	public: // Interpreter
         // TODO:

--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -56,17 +56,17 @@ namespace Prelude
 		void ReturnMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, AST::Location loc);
         void UnaryOperatorNotSupported(std::string filename, std::string op, Runtime::ValueType metType, AST::Location loc);
     public: // TypeChecker
-        void UnexpectedReturnType(std::string filename, Runtime::ValueType expected, Runtime::ValueType gotType, AST::Location loc);
-        void TypeMismatch(std::string filename, Runtime::ValueType left, Runtime::ValueType right, AST::Location loc);
-        void TypeDoesNotExist(std::string filename, Runtime::PValType typ, std::string prefix);
-        void TypeCastNotPossible(std::string filename, Runtime::PValType from, Runtime::PValType to, std::string prefix);
+        void UnexpectedReturnType(std::string filename, Runtime::PValType expected, Runtime::PValType gotType, AST::Location loc);
+        void TypeMismatch(std::string filename, Runtime::PValType left, Runtime::PValType right, AST::Location loc);
+        void TypeDoesNotExist(std::string filename, Runtime::PValType typ, AST::Location loc, std::string prefix);
+        void TypeCastNotPossible(std::string filename, Runtime::PValType from, Runtime::PValType to, AST::Location loc, std::string prefix);
     public: // TypeChecker + Interpreter
         void PrivateFunctionError(std::string filename, std::string fnName, std::string fnModule, AST::Location loc, AST::Location mLoc, std::string prefix);
         void ArgsParamsExhausted(std::string filename, std::string name, size_t argsSize, size_t paramsSize, AST::Location loc, std::string prefix);
-		void ArgMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, AST::Location loc, std::string prefix);
+		void ArgMismatchType(std::string filename, std::string name, Runtime::PValType type, Runtime::PValType expectedType, AST::Location loc, std::string prefix);
 		void UndeclaredFunction(std::string filename, std::shared_ptr<AST::Nodes::IdentifierNode> id, std::string prefix);
-		void UndeclaredFunction(std::string filename, std::shared_ptr<AST::Nodes::ObjectMember> obj, Runtime::ValueType valType, std::string prefix);
-		void OperandMismatchType(std::string filename, Runtime::ValueType leftType, Runtime::ValueType rightType, AST::Location loc, std::string prefix);
+		void UndeclaredFunction(std::string filename, std::shared_ptr<AST::Nodes::ObjectMember> obj, Runtime::PValType valType, std::string prefix);
+		void OperandMismatchType(std::string filename, Runtime::PValType leftType, Runtime::PValType rightType, AST::Location loc, std::string prefix);
 		void UndeclaredVariable(std::string filename, std::shared_ptr<AST::Nodes::IdentifierNode> id, std::string prefix);
 		void UndefinedType(std::string filename, std::string name, AST::Location loc, std::string prefix);
 		void VarMismatchType(std::string filename, std::string name, Runtime::PValType type, Runtime::PValType expectedType, AST::Location loc, std::string prefix);

--- a/tmpl-script/include/helper.h
+++ b/tmpl-script/include/helper.h
@@ -1,0 +1,21 @@
+
+#ifndef HELPER_H
+#define HELPER_H
+
+#include "interpreter/environment.h"
+#include "include/typechecker/typedf.h"
+
+namespace Helper
+{
+    class Helper
+    {
+    private:
+        using TypeDfEnv = Runtime::Environment<Runtime::TypeDf>;
+        using PTypeDfEnv = std::shared_ptr<TypeDfEnv>;
+    public:
+        static PTypeDfEnv GetTypeDefinitions();
+    };
+}
+
+#endif // HELPER_H
+

--- a/tmpl-script/include/helper.h
+++ b/tmpl-script/include/helper.h
@@ -14,6 +14,7 @@ namespace Helper
         using PTypeDfEnv = std::shared_ptr<TypeDfEnv>;
     public:
         static PTypeDfEnv GetTypeDefinitions();
+        static void DefineBuiltInType(std::string builtinName, std::string name, PTypeDfEnv env);
     };
 }
 

--- a/tmpl-script/include/interpreter.h
+++ b/tmpl-script/include/interpreter.h
@@ -1,6 +1,7 @@
 #ifndef INTERPRETER_H
 #define INTERPRETER_H
 #include <memory>
+#include "include/node/instance.h"
 #include "include/node/statement.h"
 #include "include/node/type.h"
 #include "node/return.h"
@@ -82,6 +83,7 @@ namespace Runtime
         std::shared_ptr<Value> EvaluateFunctionCall(std::shared_ptr<FunctionCall> ret); // DONE
         std::shared_ptr<Value> EvaluateIfElseStatement(std::shared_ptr<Statements::IfElseStatement> ifElse); // DONE
         std::shared_ptr<Value> EvaluateExternFunctionCall(std::string fnName, std::shared_ptr<Fn> fn, std::vector<std::shared_ptr<Node>>* args); // DONE
+        std::shared_ptr<Value> EvaluateInstance(std::shared_ptr<InstanceNode> instance); // DONE
 
 	private:
 		void EvaluateVariableDeclaration(std::shared_ptr<VarDeclaration> varDecl); // DONE

--- a/tmpl-script/include/interpreter.h
+++ b/tmpl-script/include/interpreter.h
@@ -2,6 +2,7 @@
 #define INTERPRETER_H
 #include <memory>
 #include "include/node/statement.h"
+#include "include/node/type.h"
 #include "node/return.h"
 #include "node/program.h"
 #include "parser.h"
@@ -17,18 +18,25 @@
 #include "node/unary.h"
 #include "interpreter/environment.h"
 #include "interpreter/value.h"
+#include "typechecker/typedf.h"
 
 namespace Runtime
 {
 	using namespace AST::Nodes;
 	class Interpreter
 	{
+    public:
+        using TypeDfs = Environment<TypeDf>;
+        using PTypeDfs = std::shared_ptr<Environment<TypeDf>>;
 	private:
 		std::shared_ptr<Parser> m_parser;
 		std::shared_ptr<Environment<Variable>> m_variables;
 		std::shared_ptr<Environment<Procedure>> m_procedures;
 		std::shared_ptr<Environment<Fn>> m_functions;
+
         std::shared_ptr<Environment<Environment<Fn>>> m_type_functions;
+        PTypeDfs m_type_definitions;
+
         std::shared_ptr<Environment<std::string>> m_modules;
 
         std::shared_ptr<Environment<void*>> m_handles;
@@ -41,12 +49,14 @@ namespace Runtime
                 std::shared_ptr<Environment<Procedure>> env_procedures,
                 std::shared_ptr<Environment<Fn>> env_functions,
                 std::shared_ptr<Environment<std::string>> env_modules,
-                std::shared_ptr<Environment<Environment<Fn>>> env_type_functions)
+                std::shared_ptr<Environment<Environment<Fn>>> env_type_functions,
+                PTypeDfs env_type_definitions)
             : m_parser(parser),
             m_variables(env_vars),
             m_procedures(env_procedures),
             m_functions(env_functions),
             m_type_functions(env_type_functions),
+            m_type_definitions(env_type_definitions),
             m_modules(env_modules),
             m_handles(std::make_shared<Environment<void*>>()),
             m_filename(parser->GetFilename()) { }
@@ -78,6 +88,7 @@ namespace Runtime
 		void EvaluateProcedureDeclaration(std::shared_ptr<ProcedureDeclaration> procDecl); // DONE
         void EvaluateFunctionDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported, bool externed); // DONE
         void EvaluateExportStatement(std::shared_ptr<ExportStatement> exportStmt); // DONE
+        void EvaluateTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn);
 
     private:
         inline std::string GetFilename() const { return m_filename; }

--- a/tmpl-script/include/interpreter.h
+++ b/tmpl-script/include/interpreter.h
@@ -28,7 +28,7 @@ namespace Runtime
 		std::shared_ptr<Environment<Variable>> m_variables;
 		std::shared_ptr<Environment<Procedure>> m_procedures;
 		std::shared_ptr<Environment<Fn>> m_functions;
-        std::shared_ptr<Environment<Environment<Fn>, ValueType>> m_type_functions;
+        std::shared_ptr<Environment<Environment<Fn>>> m_type_functions;
         std::shared_ptr<Environment<std::string>> m_modules;
 
         std::shared_ptr<Environment<void*>> m_handles;
@@ -41,7 +41,7 @@ namespace Runtime
                 std::shared_ptr<Environment<Procedure>> env_procedures,
                 std::shared_ptr<Environment<Fn>> env_functions,
                 std::shared_ptr<Environment<std::string>> env_modules,
-                std::shared_ptr<Environment<Environment<Fn>, ValueType>> env_type_functions)
+                std::shared_ptr<Environment<Environment<Fn>>> env_type_functions)
             : m_parser(parser),
             m_variables(env_vars),
             m_procedures(env_procedures),
@@ -56,28 +56,28 @@ namespace Runtime
         void CloseHandle(std::string handleKey);
 
 	public:
-		std::shared_ptr<Value> Execute(std::shared_ptr<Node> node);
-        void Evaluate(std::shared_ptr<ProgramNode> program);
-        void ImportModule(std::shared_ptr<RequireMacro> require);
-        void EvaluateModule(std::shared_ptr<ProgramNode> program);
+		std::shared_ptr<Value> Execute(std::shared_ptr<Node> node); // DONE
+        void Evaluate(std::shared_ptr<ProgramNode> program); // DONE
+        void ImportModule(std::shared_ptr<RequireMacro> require); // DONE
+        void EvaluateModule(std::shared_ptr<ProgramNode> program); // DONE
 
 	private:
-		std::shared_ptr<Value> EvaluateExpression(std::shared_ptr<ExpressionNode> expr);
-		std::shared_ptr<Value> EvaluateLiteral(std::shared_ptr<LiteralNode> literal);
+		std::shared_ptr<Value> EvaluateExpression(std::shared_ptr<ExpressionNode> expr); // DONE
+		std::shared_ptr<Value> EvaluateLiteral(std::shared_ptr<LiteralNode> literal); // DONE
 		std::shared_ptr<Value> EvaluateIdentifier(std::shared_ptr<IdentifierNode> identifier);
-		std::shared_ptr<Value> EvaluateCondition(std::shared_ptr<Condition> condition);
-		std::shared_ptr<Value> EvaluateTernary(std::shared_ptr<TernaryNode> ternary);
-        std::shared_ptr<Value> EvaluateUnary(std::shared_ptr<UnaryNode> unary);
-        std::shared_ptr<Value> EvaluateReturn(std::shared_ptr<ReturnNode> ret);
-        std::shared_ptr<Value> EvaluateFunctionCall(std::shared_ptr<FunctionCall> ret);
-        std::shared_ptr<Value> EvaluateIfElseStatement(std::shared_ptr<Statements::IfElseStatement> ifElse);
-        std::shared_ptr<Value> EvaluateExternFunctionCall(std::string fnName, std::shared_ptr<Fn> fn, std::vector<std::shared_ptr<Node>>* args);
+		std::shared_ptr<Value> EvaluateCondition(std::shared_ptr<Condition> condition); // DONE
+		std::shared_ptr<Value> EvaluateTernary(std::shared_ptr<TernaryNode> ternary); // DONE
+        std::shared_ptr<Value> EvaluateUnary(std::shared_ptr<UnaryNode> unary); // DONE
+        std::shared_ptr<Value> EvaluateReturn(std::shared_ptr<ReturnNode> ret); // DONE
+        std::shared_ptr<Value> EvaluateFunctionCall(std::shared_ptr<FunctionCall> ret); // DONE
+        std::shared_ptr<Value> EvaluateIfElseStatement(std::shared_ptr<Statements::IfElseStatement> ifElse); // DONE
+        std::shared_ptr<Value> EvaluateExternFunctionCall(std::string fnName, std::shared_ptr<Fn> fn, std::vector<std::shared_ptr<Node>>* args); // DONE
 
 	private:
-		void EvaluateVariableDeclaration(std::shared_ptr<VarDeclaration> varDecl);
-		void EvaluateProcedureDeclaration(std::shared_ptr<ProcedureDeclaration> procDecl);
-        void EvaluateFunctionDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported, bool externed);
-        void EvaluateExportStatement(std::shared_ptr<ExportStatement> exportStmt);
+		void EvaluateVariableDeclaration(std::shared_ptr<VarDeclaration> varDecl); // DONE
+		void EvaluateProcedureDeclaration(std::shared_ptr<ProcedureDeclaration> procDecl); // DONE
+        void EvaluateFunctionDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported, bool externed); // DONE
+        void EvaluateExportStatement(std::shared_ptr<ExportStatement> exportStmt); // DONE
 
     private:
         inline std::string GetFilename() const { return m_filename; }

--- a/tmpl-script/include/interpreter.h
+++ b/tmpl-script/include/interpreter.h
@@ -86,6 +86,9 @@ namespace Runtime
         std::shared_ptr<Value> EvaluateInstance(std::shared_ptr<InstanceNode> instance); // DONE
         std::shared_ptr<Value> EvaluateTypeCasting(std::shared_ptr<CastNode> cast); // DONE
 
+    private:
+        std::shared_ptr<Value> CastValue(std::shared_ptr<Value> val, PValType to, Location loc);
+
 	private:
 		void EvaluateVariableDeclaration(std::shared_ptr<VarDeclaration> varDecl); // DONE
 		void EvaluateProcedureDeclaration(std::shared_ptr<ProcedureDeclaration> procDecl); // DONE

--- a/tmpl-script/include/interpreter.h
+++ b/tmpl-script/include/interpreter.h
@@ -94,7 +94,7 @@ namespace Runtime
 		void EvaluateProcedureDeclaration(std::shared_ptr<ProcedureDeclaration> procDecl); // DONE
         void EvaluateFunctionDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported, bool externed); // DONE
         void EvaluateExportStatement(std::shared_ptr<ExportStatement> exportStmt); // DONE
-        void EvaluateTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn);
+        void EvaluateTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn, bool exported);
 
     private:
         inline std::string GetFilename() const { return m_filename; }

--- a/tmpl-script/include/interpreter.h
+++ b/tmpl-script/include/interpreter.h
@@ -84,6 +84,7 @@ namespace Runtime
         std::shared_ptr<Value> EvaluateIfElseStatement(std::shared_ptr<Statements::IfElseStatement> ifElse); // DONE
         std::shared_ptr<Value> EvaluateExternFunctionCall(std::string fnName, std::shared_ptr<Fn> fn, std::vector<std::shared_ptr<Node>>* args); // DONE
         std::shared_ptr<Value> EvaluateInstance(std::shared_ptr<InstanceNode> instance); // DONE
+        std::shared_ptr<Value> EvaluateTypeCasting(std::shared_ptr<CastNode> cast); // DONE
 
 	private:
 		void EvaluateVariableDeclaration(std::shared_ptr<VarDeclaration> varDecl); // DONE

--- a/tmpl-script/include/interpreter/environment.h
+++ b/tmpl-script/include/interpreter/environment.h
@@ -51,13 +51,13 @@ namespace Runtime
     class FnParam
     {
     private:
-        ValueType m_type;
+        PValType m_type;
         std::string m_name;
     public:
-        FnParam(ValueType type, std::string name) : m_type(type), m_name(name) { }
+        FnParam(PValType type, std::string name) : m_type(type), m_name(name) { }
         ~FnParam() = default;
     public:
-        inline ValueType GetType() const { return m_type; }
+        inline PValType GetType() const { return m_type; }
         inline std::string GetName() const { return m_name; }
     };
 

--- a/tmpl-script/include/interpreter/environment.h
+++ b/tmpl-script/include/interpreter/environment.h
@@ -86,6 +86,7 @@ namespace Runtime
 
     public:
         void AddParam(std::shared_ptr<FnParam> param) { m_params.push_back(param); }
+		void SetReturnType(PValType newTyp) { m_ret_type = newTyp; }
     public:
         inline std::shared_ptr<FnParam> GetItem(unsigned int index) { return m_params[index]; }
 

--- a/tmpl-script/include/interpreter/environment.h
+++ b/tmpl-script/include/interpreter/environment.h
@@ -17,12 +17,12 @@ namespace Runtime
 	private:
 		// TODO:
 		// `std::string m_typename;` - for complex type names, e.g. Point<int> instead of object {x: int, y: int}
-		ValueType m_type;
+		PValType m_type;
 		std::shared_ptr<Value> m_value;
 		bool m_editable;
 
 	public:
-		Variable(ValueType type, std::shared_ptr<Value> value, bool editable)
+		Variable(PValType type, std::shared_ptr<Value> value, bool editable)
 			: m_type(type), m_value(value), m_editable(editable) {}
 
 	public:
@@ -66,7 +66,7 @@ namespace Runtime
 	private:
 		std::shared_ptr<Node> m_body;
         std::vector<std::shared_ptr<FnParam>> m_params;
-        ValueType m_ret_type;
+        PValType m_ret_type;
 
         std::string m_module_name;
         bool m_exported;
@@ -76,7 +76,7 @@ namespace Runtime
         size_t m_index;
 
 	public:
-		Fn(std::shared_ptr<Node> body, ValueType retType, std::string module, bool exported, bool externed, Location loc)
+		Fn(std::shared_ptr<Node> body, PValType retType, std::string module, bool exported, bool externed, Location loc)
 			: m_body(body),
             m_ret_type(retType),
             m_params(std::vector<std::shared_ptr<FnParam>>()),
@@ -92,7 +92,7 @@ namespace Runtime
 	public:
 		inline std::shared_ptr<Node> GetBody() const { return m_body; }
         inline size_t GetParamsSize() const { return m_params.size(); }
-        inline ValueType GetReturnType() const { return m_ret_type; }
+        inline PValType GetReturnType() const { return m_ret_type; }
         inline std::string GetModuleName() const { return m_module_name; }
         inline bool IsExported() const { return m_exported; }
         inline bool IsExterned() const { return m_externed; }

--- a/tmpl-script/include/interpreter/value.h
+++ b/tmpl-script/include/interpreter/value.h
@@ -25,18 +25,16 @@ namespace Runtime
     {
     private:
         std::string m_name;
-        AST::Location m_loc;
 
     public:
-        CustomValueType(std::string name, AST::Location loc)
-            : m_name(name), m_loc(loc) { }
+        CustomValueType(std::string name)
+            : m_name(name) { }
 
     public:
         bool Compare(const CustomValueType& other) { return m_name == other.m_name; }
 
     public:
         inline std::string GetName() const { return m_name; }
-        inline AST::Location GetLocation() const { return m_loc; }
 
     public:
         friend std::ostream &operator<<(std::ostream& stream, const CustomValueType &x);

--- a/tmpl-script/include/interpreter/value.h
+++ b/tmpl-script/include/interpreter/value.h
@@ -25,13 +25,18 @@ namespace Runtime
     {
     private:
         std::string m_name;
+        AST::Location m_loc;
 
     public:
-        CustomValueType(std::string name)
-            : m_name(name) { }
+        CustomValueType(std::string name, AST::Location loc)
+            : m_name(name), m_loc(loc) { }
 
     public:
         bool Compare(const CustomValueType& other) { return m_name == other.m_name; }
+
+    public:
+        inline std::string GetName() const { return m_name; }
+        inline AST::Location GetLocation() const { return m_loc; }
 
     public:
         friend std::ostream &operator<<(std::ostream& stream, const CustomValueType &x);

--- a/tmpl-script/include/interpreter/value.h
+++ b/tmpl-script/include/interpreter/value.h
@@ -125,6 +125,7 @@ namespace Runtime
 
 	public:
 		inline bool GetValue() const { return m_value; }
+        void SetValue(bool newValue) { m_value = newValue; }
 
 	public:
 		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;
@@ -157,6 +158,7 @@ namespace Runtime
 
 	public:
 		inline std::shared_ptr<int> GetValue() const { return m_value; }
+        void SetValue(int newValue) { *m_value = newValue; }
 
 	public:
 		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;
@@ -220,6 +222,7 @@ namespace Runtime
 
 	public:
 		inline std::shared_ptr<float> GetValue() const { return m_value; }
+        void SetValue(float newValue) { *m_value = newValue; }
 
     public:
         FloatValue(const FloatValue* val) : Value(val->GetType())
@@ -251,6 +254,7 @@ namespace Runtime
 
 	public:
 		inline std::shared_ptr<double> GetValue() const { return m_value; }
+        void SetValue(double newValue) { *m_value = newValue; }
 
 	public:
 		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;
@@ -282,6 +286,7 @@ namespace Runtime
 
 	public:
 		inline std::shared_ptr<std::string> GetValue() const { return m_value; }
+        void SetValue(std::string newValue) { *m_value = newValue; }
 
 	public:
 		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;

--- a/tmpl-script/include/interpreter/value.h
+++ b/tmpl-script/include/interpreter/value.h
@@ -104,10 +104,10 @@ namespace Runtime
 		std::string format() const override;
 	};
 
-	class NullValue : public Value
+	class VoidValue : public Value
 	{
 	public:
-		NullValue() { }
+		VoidValue() { }
 
 	public:
 		inline PValType GetType() const override { return std::make_shared<ValType>("void"); }

--- a/tmpl-script/include/interpreter/value.h
+++ b/tmpl-script/include/interpreter/value.h
@@ -1,6 +1,7 @@
 #ifndef RUNTIME_VALUE_H
 #define RUNTIME_VALUE_H
 #include <memory>
+#include <ostream>
 #include <string>
 #include <cassert>
 #include <vector>
@@ -28,9 +29,16 @@ namespace Runtime
     public:
         CustomValueType(std::string name)
             : m_name(name) { }
+
+    public:
+        bool Compare(const CustomValueType& other) { return m_name == other.m_name; }
+
+    public:
+        friend std::ostream &operator<<(std::ostream& stream, const CustomValueType &x);
     };
 
-    typedef std::shared_ptr<CustomValueType> PValType;
+    typedef CustomValueType ValType;
+    typedef std::shared_ptr<ValType> PValType;
 
     static std::string HumanValueType(ValueType type)
     {

--- a/tmpl-script/include/interpreter/value.h
+++ b/tmpl-script/include/interpreter/value.h
@@ -87,32 +87,6 @@ namespace Runtime
 	std::ostream &operator<<(std::ostream &stream, const Value &value);
 	std::ostream &operator<<(std::ostream &stream, const std::shared_ptr<Value> &value);
 
-
-	class ListValue : public Value
-	{
-	private:
-		std::vector<std::shared_ptr<Value>> m_value;
-
-	public:
-		ListValue()
-            : m_value(std::vector<std::shared_ptr<Value>>()),
-              Value(std::make_shared<ValType>("list")) {}
-		ListValue(std::vector<std::shared_ptr<Value>> values)
-            : m_value(values),
-              Value(std::make_shared<ValType>("list")) {}
-
-	public:
-		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;
-		std::shared_ptr<Value> Operate(std::shared_ptr<Value> right, AST::Nodes::ExpressionNode::OperatorType opType) override;
-
-    public:
-        void AddItem(std::shared_ptr<Value> item);
-        std::shared_ptr<Value> GetItem(std::shared_ptr<Value> indexVal);
-
-	public:
-		std::string format() const override;
-	};
-
 	class VoidValue : public Value
 	{
 	public:
@@ -164,6 +138,32 @@ namespace Runtime
 	public:
 		std::string format() const override;
 	};
+
+	class ListValue : public Value
+	{
+	private:
+		std::vector<std::shared_ptr<Value>> m_value;
+
+	public:
+		ListValue()
+            : m_value(std::vector<std::shared_ptr<Value>>()),
+              Value(std::make_shared<ValType>("list")) {}
+		ListValue(std::vector<std::shared_ptr<Value>> values)
+            : m_value(values),
+              Value(std::make_shared<ValType>("list")) {}
+
+	public:
+		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;
+		std::shared_ptr<Value> Operate(std::shared_ptr<Value> right, AST::Nodes::ExpressionNode::OperatorType opType) override;
+
+    public:
+        void AddItem(std::shared_ptr<Value> item);
+        std::shared_ptr<Value> GetItem(std::shared_ptr<IntegerValue> indexVal);
+
+	public:
+		std::string format() const override;
+	};
+
 	class FloatValue : public Value
 	{
 	private:

--- a/tmpl-script/include/interpreter/value.h
+++ b/tmpl-script/include/interpreter/value.h
@@ -79,6 +79,9 @@ namespace Runtime
 
 	public:
 		virtual std::string format() const = 0;
+
+    public:
+        virtual std::shared_ptr<Value> Clone() const = 0;
     
     public:
         void SetType(PValType newTyp) { m_value_type = newTyp; }
@@ -98,6 +101,12 @@ namespace Runtime
 
 	public:
 		std::string format() const override;
+
+    public:
+        std::shared_ptr<Value> Clone() const override
+        {
+            return std::make_shared<VoidValue>();
+        }
 	};
 
 	class BoolValue : public Value
@@ -117,6 +126,12 @@ namespace Runtime
 
 	public:
 		std::string format() const override;
+
+    public:
+        std::shared_ptr<Value> Clone() const override
+        {
+            return std::make_shared<BoolValue>(m_value);
+        }
 	};
 
 	class IntegerValue : public Value
@@ -137,6 +152,12 @@ namespace Runtime
 
 	public:
 		std::string format() const override;
+
+    public:
+        std::shared_ptr<Value> Clone() const override
+        {
+            return std::make_shared<IntegerValue>(m_value);
+        }
 	};
 
 	class ListValue : public Value
@@ -162,6 +183,12 @@ namespace Runtime
 
 	public:
 		std::string format() const override;
+
+    public:
+        std::shared_ptr<Value> Clone() const override
+        {
+            return std::make_shared<ListValue>(m_value);
+        }
 	};
 
 	class FloatValue : public Value
@@ -182,6 +209,12 @@ namespace Runtime
 
 	public:
 		std::string format() const override;
+
+    public:
+        std::shared_ptr<Value> Clone() const override
+        {
+            return std::make_shared<FloatValue>(m_value);
+        }
 	};
 	class DoubleValue : public Value
 	{
@@ -201,6 +234,12 @@ namespace Runtime
 
 	public:
 		std::string format() const override;
+
+    public:
+        std::shared_ptr<Value> Clone() const override
+        {
+            return std::make_shared<DoubleValue>(m_value);
+        }
 	};
 	class StringValue : public Value
 	{
@@ -220,6 +259,12 @@ namespace Runtime
 
 	public:
 		std::string format() const override;
+
+    public:
+        std::shared_ptr<Value> Clone() const override
+        {
+            return std::make_shared<StringValue>(m_value);
+        }
 	};
 }
 

--- a/tmpl-script/include/interpreter/value.h
+++ b/tmpl-script/include/interpreter/value.h
@@ -20,6 +20,16 @@ namespace Runtime
 		Null,
 	};
 
+    struct CustomValueType
+    {
+    private:
+        std::string m_name;
+
+    public:
+        CustomValueType(std::string name)
+            : m_name(name) { }
+    };
+
     static std::string HumanValueType(ValueType type)
     {
         switch(type)
@@ -40,10 +50,6 @@ namespace Runtime
 	{
 	public:
 		inline virtual ValueType GetType() const = 0;
-
-	public:
-		template <typename T>
-		inline T *Get() { return static_cast<T *>(this); }
 
 	public:
 		virtual std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) = 0;

--- a/tmpl-script/include/interpreter/value.h
+++ b/tmpl-script/include/interpreter/value.h
@@ -30,6 +30,8 @@ namespace Runtime
             : m_name(name) { }
     };
 
+    typedef std::shared_ptr<CustomValueType> PValType;
+
     static std::string HumanValueType(ValueType type)
     {
         switch(type)

--- a/tmpl-script/include/interpreter/value.h
+++ b/tmpl-script/include/interpreter/value.h
@@ -117,6 +117,12 @@ namespace Runtime
 	public:
 		BoolValue(bool value) : m_value(value), Value(std::make_shared<ValType>("bool")) {}
 
+    public:
+        BoolValue(const BoolValue* val) : Value(val->GetType())
+        {
+            m_value = val->m_value;
+        }
+
 	public:
 		inline bool GetValue() const { return m_value; }
 
@@ -130,7 +136,7 @@ namespace Runtime
     public:
         std::shared_ptr<Value> Clone() const override
         {
-            return std::make_shared<BoolValue>(m_value);
+            return std::make_shared<BoolValue>(this);
         }
 	};
 
@@ -142,6 +148,12 @@ namespace Runtime
 	public:
 		IntegerValue(std::shared_ptr<int> value) : m_value(value), Value(std::make_shared<ValType>("int")) {}
 		IntegerValue(int value) : m_value(std::make_shared<int>(value)), Value(std::make_shared<ValType>("int")) {}
+
+    public:
+        IntegerValue(const IntegerValue* val) : Value(val->GetType())
+        {
+            m_value = val->m_value;
+        }
 
 	public:
 		inline std::shared_ptr<int> GetValue() const { return m_value; }
@@ -156,7 +168,7 @@ namespace Runtime
     public:
         std::shared_ptr<Value> Clone() const override
         {
-            return std::make_shared<IntegerValue>(m_value);
+            return std::make_shared<IntegerValue>(this);
         }
 	};
 
@@ -178,6 +190,12 @@ namespace Runtime
 		std::shared_ptr<Value> Operate(std::shared_ptr<Value> right, AST::Nodes::ExpressionNode::OperatorType opType) override;
 
     public:
+        ListValue(const ListValue* val) : Value(val->GetType())
+        {
+            m_value = val->m_value;
+        }
+
+    public:
         void AddItem(std::shared_ptr<Value> item);
         std::shared_ptr<Value> GetItem(std::shared_ptr<IntegerValue> indexVal);
 
@@ -187,7 +205,7 @@ namespace Runtime
     public:
         std::shared_ptr<Value> Clone() const override
         {
-            return std::make_shared<ListValue>(m_value);
+            return std::make_shared<ListValue>(this);
         }
 	};
 
@@ -203,6 +221,12 @@ namespace Runtime
 	public:
 		inline std::shared_ptr<float> GetValue() const { return m_value; }
 
+    public:
+        FloatValue(const FloatValue* val) : Value(val->GetType())
+        {
+            m_value = val->m_value;
+        }
+
 	public:
 		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;
 		std::shared_ptr<Value> Operate(std::shared_ptr<Value> right, AST::Nodes::ExpressionNode::OperatorType opType) override;
@@ -213,7 +237,7 @@ namespace Runtime
     public:
         std::shared_ptr<Value> Clone() const override
         {
-            return std::make_shared<FloatValue>(m_value);
+            return std::make_shared<FloatValue>(this);
         }
 	};
 	class DoubleValue : public Value
@@ -232,13 +256,19 @@ namespace Runtime
 		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;
 		std::shared_ptr<Value> Operate(std::shared_ptr<Value> right, AST::Nodes::ExpressionNode::OperatorType opType) override;
 
+    public:
+        DoubleValue(const DoubleValue* val) : Value(val->GetType())
+        {
+            m_value = val->m_value;
+        }
+
 	public:
 		std::string format() const override;
 
     public:
         std::shared_ptr<Value> Clone() const override
         {
-            return std::make_shared<DoubleValue>(m_value);
+            return std::make_shared<DoubleValue>(this);
         }
 	};
 	class StringValue : public Value
@@ -257,13 +287,19 @@ namespace Runtime
 		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;
 		std::shared_ptr<Value> Operate(std::shared_ptr<Value> right, AST::Nodes::ExpressionNode::OperatorType opType) override;
 
+    public:
+        StringValue(const StringValue* val) : Value(val->GetType())
+        {
+            m_value = val->m_value;
+        }
+
 	public:
 		std::string format() const override;
 
     public:
         std::shared_ptr<Value> Clone() const override
         {
-            return std::make_shared<StringValue>(m_value);
+            return std::make_shared<StringValue>(this);
         }
 	};
 }

--- a/tmpl-script/include/interpreter/value.h
+++ b/tmpl-script/include/interpreter/value.h
@@ -53,7 +53,7 @@ namespace Runtime
             case ValueType::Double: return "double";
             case ValueType::Bool: return "bool";
             case ValueType::List: return "list";
-            case ValueType::Null: return "null";
+            case ValueType::Null: return "void";
         }
 
         return "UNKNOWN_TYPE";
@@ -62,7 +62,7 @@ namespace Runtime
 	class Value
 	{
 	public:
-		inline virtual ValueType GetType() const = 0;
+		inline virtual PValType GetType() const = 0;
 
 	public:
 		virtual std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) = 0;
@@ -90,7 +90,7 @@ namespace Runtime
             : m_value(values) {}
 
 	public:
-		inline ValueType GetType() const override { return ValueType::List; }
+		inline PValType GetType() const override { return std::make_shared<ValType>("list"); }
 
 	public:
 		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;
@@ -110,7 +110,7 @@ namespace Runtime
 		NullValue() { }
 
 	public:
-		inline ValueType GetType() const override { return ValueType::Null; }
+		inline PValType GetType() const override { return std::make_shared<ValType>("void"); }
 
 	public:
 		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;
@@ -129,7 +129,7 @@ namespace Runtime
 		BoolValue(bool value) : m_value(value) {}
 
 	public:
-		inline ValueType GetType() const override { return ValueType::Bool; }
+		inline PValType GetType() const override { return std::make_shared<ValType>("bool"); }
 
 	public:
 		inline bool GetValue() const { return m_value; }
@@ -152,7 +152,7 @@ namespace Runtime
 		IntegerValue(int value) : m_value(std::make_shared<int>(value)) {}
 
 	public:
-		inline ValueType GetType() const override { return ValueType::Integer; }
+		inline PValType GetType() const override { return std::make_shared<ValType>("int"); }
 
 	public:
 		inline std::shared_ptr<int> GetValue() const { return m_value; }
@@ -174,7 +174,7 @@ namespace Runtime
 		FloatValue(float value) : m_value(std::make_shared<float>(value)) {}
 
 	public:
-		inline ValueType GetType() const override { return ValueType::Float; }
+		inline PValType GetType() const override { return std::make_shared<ValType>("float"); }
 
 	public:
 		inline std::shared_ptr<float> GetValue() const { return m_value; }
@@ -196,7 +196,7 @@ namespace Runtime
 		DoubleValue(double value) : m_value(std::make_shared<double>(value)) {}
 
 	public:
-		inline ValueType GetType() const override { return ValueType::Double; }
+		inline PValType GetType() const override { return std::make_shared<ValType>("double"); }
 
 	public:
 		inline std::shared_ptr<double> GetValue() const { return m_value; }
@@ -218,7 +218,7 @@ namespace Runtime
 		StringValue(std::string value) : m_value(std::make_shared<std::string>(value)) {}
 
 	public:
-		inline ValueType GetType() const override { return ValueType::String; }
+		inline PValType GetType() const override { return std::make_shared<ValType>("string"); }
 
 	public:
 		inline std::shared_ptr<std::string> GetValue() const { return m_value; }

--- a/tmpl-script/include/interpreter/value.h
+++ b/tmpl-script/include/interpreter/value.h
@@ -61,8 +61,11 @@ namespace Runtime
 
 	class Value
 	{
+    private:
+        PValType m_value_type;
+
 	public:
-		inline virtual PValType GetType() const = 0;
+		inline PValType GetType() const { return m_value_type; };
 
 	public:
 		virtual std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) = 0;
@@ -71,8 +74,14 @@ namespace Runtime
 	public:
 		virtual ~Value() = default;
 
+    public:
+        Value(PValType valType) : m_value_type(valType) { }
+
 	public:
 		virtual std::string format() const = 0;
+    
+    public:
+        void SetType(PValType newTyp) { m_value_type = newTyp; }
 	};
 
 	std::ostream &operator<<(std::ostream &stream, const Value &value);
@@ -85,12 +94,12 @@ namespace Runtime
 		std::vector<std::shared_ptr<Value>> m_value;
 
 	public:
-		ListValue() : m_value(std::vector<std::shared_ptr<Value>>()) {}
+		ListValue()
+            : m_value(std::vector<std::shared_ptr<Value>>()),
+              Value(std::make_shared<ValType>("list")) {}
 		ListValue(std::vector<std::shared_ptr<Value>> values)
-            : m_value(values) {}
-
-	public:
-		inline PValType GetType() const override { return std::make_shared<ValType>("list"); }
+            : m_value(values),
+              Value(std::make_shared<ValType>("list")) {}
 
 	public:
 		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;
@@ -107,10 +116,7 @@ namespace Runtime
 	class VoidValue : public Value
 	{
 	public:
-		VoidValue() { }
-
-	public:
-		inline PValType GetType() const override { return std::make_shared<ValType>("void"); }
+		VoidValue() : Value(std::make_shared<ValType>("void")) { }
 
 	public:
 		std::shared_ptr<Value> Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition) override;
@@ -126,10 +132,7 @@ namespace Runtime
 		bool m_value;
 
 	public:
-		BoolValue(bool value) : m_value(value) {}
-
-	public:
-		inline PValType GetType() const override { return std::make_shared<ValType>("bool"); }
+		BoolValue(bool value) : m_value(value), Value(std::make_shared<ValType>("bool")) {}
 
 	public:
 		inline bool GetValue() const { return m_value; }
@@ -148,11 +151,8 @@ namespace Runtime
 		std::shared_ptr<int> m_value;
 
 	public:
-		IntegerValue(std::shared_ptr<int> value) : m_value(value) {}
-		IntegerValue(int value) : m_value(std::make_shared<int>(value)) {}
-
-	public:
-		inline PValType GetType() const override { return std::make_shared<ValType>("int"); }
+		IntegerValue(std::shared_ptr<int> value) : m_value(value), Value(std::make_shared<ValType>("int")) {}
+		IntegerValue(int value) : m_value(std::make_shared<int>(value)), Value(std::make_shared<ValType>("int")) {}
 
 	public:
 		inline std::shared_ptr<int> GetValue() const { return m_value; }
@@ -170,11 +170,8 @@ namespace Runtime
 		std::shared_ptr<float> m_value;
 
 	public:
-		FloatValue(std::shared_ptr<float> value) : m_value(value) {}
-		FloatValue(float value) : m_value(std::make_shared<float>(value)) {}
-
-	public:
-		inline PValType GetType() const override { return std::make_shared<ValType>("float"); }
+		FloatValue(std::shared_ptr<float> value) : m_value(value), Value(std::make_shared<ValType>("float")) {}
+		FloatValue(float value) : m_value(std::make_shared<float>(value)), Value(std::make_shared<ValType>("float")) {}
 
 	public:
 		inline std::shared_ptr<float> GetValue() const { return m_value; }
@@ -192,11 +189,8 @@ namespace Runtime
 		std::shared_ptr<double> m_value;
 
 	public:
-		DoubleValue(std::shared_ptr<double> value) : m_value(value) {}
-		DoubleValue(double value) : m_value(std::make_shared<double>(value)) {}
-
-	public:
-		inline PValType GetType() const override { return std::make_shared<ValType>("double"); }
+		DoubleValue(std::shared_ptr<double> value) : m_value(value), Value(std::make_shared<ValType>("double")) {}
+		DoubleValue(double value) : m_value(std::make_shared<double>(value)), Value(std::make_shared<ValType>("double")) {}
 
 	public:
 		inline std::shared_ptr<double> GetValue() const { return m_value; }
@@ -214,11 +208,8 @@ namespace Runtime
 		std::shared_ptr<std::string> m_value;
 
 	public:
-		StringValue(std::shared_ptr<std::string> value) : m_value(value) {}
-		StringValue(std::string value) : m_value(std::make_shared<std::string>(value)) {}
-
-	public:
-		inline PValType GetType() const override { return std::make_shared<ValType>("string"); }
+		StringValue(std::shared_ptr<std::string> value) : m_value(value), Value(std::make_shared<ValType>("string")) {}
+		StringValue(std::string value) : m_value(std::make_shared<std::string>(value)), Value(std::make_shared<ValType>("string")) {}
 
 	public:
 		inline std::shared_ptr<std::string> GetValue() const { return m_value; }

--- a/tmpl-script/include/lexer.h
+++ b/tmpl-script/include/lexer.h
@@ -8,6 +8,13 @@
 
 namespace AST
 {
+    struct LexerState
+    {
+        size_t index;
+
+        LexerState(size_t i) : index(i) {}
+    };
+
 	class Lexer
 	{
 	private:
@@ -22,6 +29,7 @@ namespace AST
 
 	private: // token manager
 		size_t m_index;
+        std::shared_ptr<LexerState> m_state;
 
 	public:
 		Lexer(std::string code) : m_code(code)
@@ -38,6 +46,10 @@ namespace AST
 
 	public:
 		std::vector<std::shared_ptr<Token>> &GetTokens() { return m_tokens; };
+
+    public:
+        void SaveState() { m_state = std::make_shared<LexerState>(m_index); }
+        void RestoreState();
 
 	public:
 		void Tokenize();

--- a/tmpl-script/include/node.h
+++ b/tmpl-script/include/node.h
@@ -31,6 +31,7 @@ namespace AST
         Require, // 
         Export, // 
         Extern, //
+        Type,
     };
 
 	class Node

--- a/tmpl-script/include/node.h
+++ b/tmpl-script/include/node.h
@@ -35,6 +35,7 @@ namespace AST
         TypeTemplate,
         TypeDf,
         Instance,
+        Cast,
     };
 
 	class Node

--- a/tmpl-script/include/node.h
+++ b/tmpl-script/include/node.h
@@ -32,6 +32,7 @@ namespace AST
         Export, // 
         Extern, //
         Type,
+        TypeTemplate,
     };
 
 	class Node

--- a/tmpl-script/include/node.h
+++ b/tmpl-script/include/node.h
@@ -34,6 +34,7 @@ namespace AST
         Type,
         TypeTemplate,
         TypeDf,
+        Instance,
     };
 
 	class Node

--- a/tmpl-script/include/node.h
+++ b/tmpl-script/include/node.h
@@ -33,6 +33,7 @@ namespace AST
         Extern, //
         Type,
         TypeTemplate,
+        TypeDf,
     };
 
 	class Node

--- a/tmpl-script/include/node/cast.h
+++ b/tmpl-script/include/node/cast.h
@@ -26,6 +26,10 @@ namespace AST
 
         public:
             std::string Format() const override;
+
+        public:
+            inline PTypeNode GetTypeNode() const { return m_type; }
+            inline PNode GetExpr() const { return m_expr; }
         };
     }
 }

--- a/tmpl-script/include/node/cast.h
+++ b/tmpl-script/include/node/cast.h
@@ -1,0 +1,34 @@
+#ifndef CAST_NODE_H
+#define CAST_NODE_H
+
+#include "../node.h"
+#include "type.h"
+
+namespace AST
+{
+    namespace Nodes
+    {
+        class CastNode : public Node
+        {
+        private:
+            using PTypeNode = std::shared_ptr<TypeNode>;
+            using PNode = std::shared_ptr<Node>;
+        private:
+            std::shared_ptr<TypeNode> m_type;
+            std::shared_ptr<Node> m_expr;
+
+        public:
+            CastNode(PTypeNode typ, PNode expr, Location loc)
+                : m_type(typ), m_expr(expr), Node(loc) { }
+
+        public:
+            inline NodeType GetType() const override { return NodeType::Cast; };
+
+        public:
+            std::string Format() const override;
+        };
+    }
+}
+
+#endif // CAST_NODE_H
+

--- a/tmpl-script/include/node/function.h
+++ b/tmpl-script/include/node/function.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include "../node.h"
 #include "../location.h"
+#include "include/node/type.h"
 #include "statement.h"
 #include "identifier.h"
 
@@ -34,14 +35,14 @@ namespace AST
         class FunctionParam
         {
         private:
-            std::shared_ptr<Node> m_type;
+            std::shared_ptr<TypeNode> m_type;
             std::shared_ptr<IdentifierNode> m_name;
         public:
-            FunctionParam(std::shared_ptr<Node> type, std::shared_ptr<IdentifierNode> name)
+            FunctionParam(std::shared_ptr<TypeNode> type, std::shared_ptr<IdentifierNode> name)
                 : m_type(type), m_name(name) { }
             ~FunctionParam() = default;
         public:
-            inline std::shared_ptr<Node> GetType() const { return m_type; }
+            inline std::shared_ptr<TypeNode> GetType() const { return m_type; }
             inline std::shared_ptr<IdentifierNode> GetName() const { return m_name; }
         };
 
@@ -50,7 +51,7 @@ namespace AST
         private:
             std::shared_ptr<Node> m_name;
             std::vector<std::shared_ptr<FunctionParam>> m_params;
-            std::shared_ptr<Node> m_ret_type;
+            std::shared_ptr<TypeNode> m_ret_type;
             std::shared_ptr<Statements::StatementsBody> m_body;
         private:
             size_t m_index;
@@ -69,10 +70,10 @@ namespace AST
             ~FunctionDeclaration() = default;
         public:
             void AddParam(std::shared_ptr<FunctionParam> param);
-            void SetReturnType(std::shared_ptr<Node> retType) { m_ret_type = retType; }
+            void SetReturnType(std::shared_ptr<TypeNode> retType) { m_ret_type = retType; }
         public:
             inline std::shared_ptr<Node> GetName() const { return m_name; }
-            inline std::shared_ptr<Node> GetReturnType() const { return m_ret_type; }
+            inline std::shared_ptr<TypeNode> GetReturnType() const { return m_ret_type; }
             inline std::shared_ptr<Statements::StatementsBody> GetBody() const { return m_body; }
         public:
             inline std::shared_ptr<FunctionParam> GetItem(unsigned int index)

--- a/tmpl-script/include/node/function.h
+++ b/tmpl-script/include/node/function.h
@@ -46,6 +46,12 @@ namespace AST
             inline std::shared_ptr<IdentifierNode> GetName() const { return m_name; }
         };
 
+        enum class FunctionModifier
+        {
+            Construct,
+            None,
+        };
+
         class FunctionDeclaration : public Node
         {
         private:
@@ -53,18 +59,21 @@ namespace AST
             std::vector<std::shared_ptr<FunctionParam>> m_params;
             std::shared_ptr<TypeNode> m_ret_type;
             std::shared_ptr<Statements::StatementsBody> m_body;
+            FunctionModifier m_modifier;
         private:
             size_t m_index;
         public:
             FunctionDeclaration(
                     std::shared_ptr<Node> name,
                     std::shared_ptr<Statements::StatementsBody> body,
+                    FunctionModifier modifier,
                     Location loc
                     )
                 : m_name(name),
                 m_params(std::vector<std::shared_ptr<FunctionParam>>()),
                 m_ret_type(nullptr),
                 m_body(body),
+                m_modifier(modifier),
                 m_index(0),
                 Node(loc) { }
             ~FunctionDeclaration() = default;
@@ -75,6 +84,7 @@ namespace AST
             inline std::shared_ptr<Node> GetName() const { return m_name; }
             inline std::shared_ptr<TypeNode> GetReturnType() const { return m_ret_type; }
             inline std::shared_ptr<Statements::StatementsBody> GetBody() const { return m_body; }
+            inline FunctionModifier GetModifier() const { return m_modifier; }
         public:
             inline std::shared_ptr<FunctionParam> GetItem(unsigned int index)
                 { return m_params[index]; }

--- a/tmpl-script/include/node/function.h
+++ b/tmpl-script/include/node/function.h
@@ -49,6 +49,7 @@ namespace AST
         enum class FunctionModifier
         {
             Construct,
+            Cast,
             None,
         };
 

--- a/tmpl-script/include/node/instance.h
+++ b/tmpl-script/include/node/instance.h
@@ -1,0 +1,34 @@
+#ifndef INSTANCE_NODE_H
+#define INSTANCE_NODE_H
+
+#include "../node.h"
+#include "function.h"
+#include "type.h"
+
+namespace AST
+{
+    namespace Nodes
+    {
+        class InstanceNode : public Node
+        {
+        private:
+            std::shared_ptr<TypeNode> m_target;
+            std::shared_ptr<FunctionCall> m_fcall;
+
+        public:
+            InstanceNode(std::shared_ptr<TypeNode> target, std::shared_ptr<FunctionCall> fcall, Location loc)
+                : m_target(target), m_fcall(fcall), Node(loc) { }
+            ~InstanceNode() = default;
+        public:
+            inline NodeType GetType() const override { return NodeType::Instance; }
+            std::string Format() const override;
+
+        public:
+            inline std::shared_ptr<TypeNode> GetTarget() const { return m_target; }
+            inline std::shared_ptr<FunctionCall> GetFunctionCall() const { return m_fcall; }
+        };
+    }
+}
+
+#endif // INSTANCE_NODE_H
+

--- a/tmpl-script/include/node/type.h
+++ b/tmpl-script/include/node/type.h
@@ -15,7 +15,7 @@ namespace AST
         public:
             using PId = std::shared_ptr<IdentifierNode>;
         private:
-            std::shared_ptr<IdentifierNode> m_typename;
+            PId m_typename;
             // TODO:
             // std::vector<std::shared_ptr<...>> m_generics;
 
@@ -29,6 +29,45 @@ namespace AST
 
         public:
             inline PId GetTypeName() const { return m_typename; }
+        };
+
+        class TypeTemplateNode : public Node
+        {
+        public:
+            using PId = std::shared_ptr<IdentifierNode>;
+        private:
+            PId m_typename;
+            // TODO:
+            // std::vector<std::shared_ptr<...>> m_generics;
+
+        public:
+            TypeTemplateNode(PId target, Location loc)
+                : m_typename(target), Node(loc) { }
+
+        public:
+            inline NodeType GetType() const override { return NodeType::TypeTemplate; };
+            std::string Format() const override;
+
+        public:
+            inline PId GetTypeName() const { return m_typename; }
+        };
+
+        class TypeDfNode : public Node
+        {
+        public:
+            using PTypeTmpl = std::shared_ptr<TypeTemplateNode>;
+            using PType = std::shared_ptr<TypeNode>;
+        private:
+            PTypeTmpl m_template;
+            PType m_value;
+
+        public:
+            TypeDfNode(PTypeTmpl tmpl, PType value, Location loc)
+                : m_template(tmpl), m_value(value), Node(loc) { }
+
+        public:
+            inline PTypeTmpl GetTypeTemplate() const { return m_template; }
+            inline PType GetTypeValue() const { return m_value; }
         };
     }
 }

--- a/tmpl-script/include/node/type.h
+++ b/tmpl-script/include/node/type.h
@@ -66,6 +66,10 @@ namespace AST
                 : m_template(tmpl), m_value(value), Node(loc) { }
 
         public:
+            inline NodeType GetType() const override { return NodeType::TypeDf; };
+            std::string Format() const override;
+
+        public:
             inline PTypeTmpl GetTypeTemplate() const { return m_template; }
             inline PType GetTypeValue() const { return m_value; }
         };

--- a/tmpl-script/include/node/type.h
+++ b/tmpl-script/include/node/type.h
@@ -1,0 +1,33 @@
+
+#ifndef TYPE_NODE_H
+#define TYPE_NODE_H
+
+#include <memory>
+#include "../node.h"
+#include "include/node/identifier.h"
+
+namespace AST
+{
+    namespace Nodes
+    {
+        class TypeNode : public Node
+        {
+        public:
+            using PId = std::shared_ptr<IdentifierNode>;
+        private:
+            std::shared_ptr<IdentifierNode> m_typename;
+            // TODO:
+            // std::vector<std::shared_ptr<...>> m_generics;
+
+        public:
+            TypeNode(PId target, Location loc)
+                : m_typename(target), Node(loc) { }
+
+        public:
+            inline PId GetTypeName() const { return m_typename; }
+        };
+    }
+}
+
+#endif // TYPE_NODE_H
+

--- a/tmpl-script/include/node/type.h
+++ b/tmpl-script/include/node/type.h
@@ -24,6 +24,10 @@ namespace AST
                 : m_typename(target), Node(loc) { }
 
         public:
+            inline NodeType GetType() const override { return NodeType::Type; };
+            std::string Format() const override;
+
+        public:
             inline PId GetTypeName() const { return m_typename; }
         };
     }

--- a/tmpl-script/include/node/var_declaration.h
+++ b/tmpl-script/include/node/var_declaration.h
@@ -5,6 +5,7 @@
 #include<string>
 #include<memory>
 #include"../node.h"
+#include "include/node/type.h"
 
 namespace AST
 {
@@ -13,7 +14,7 @@ namespace AST
 		class VarDeclaration : public Node
 		{
 		private:
-			std::shared_ptr<Node> m_type;
+			std::shared_ptr<TypeNode> m_type;
 			std::shared_ptr<std::string> m_name;
 			std::shared_ptr<Node> m_value; // nullable
 			bool m_editable;
@@ -22,12 +23,12 @@ namespace AST
 		public:
 			std::string Format() const override { return "VarDecl()"; }
 		public:
-			VarDeclaration(std::shared_ptr<Node> type, std::shared_ptr<std::string> name, std::shared_ptr<Node> value, bool editable, Location loc)
+			VarDeclaration(std::shared_ptr<TypeNode> type, std::shared_ptr<std::string> name, std::shared_ptr<Node> value, bool editable, Location loc)
 				: m_type(type), m_name(name), m_value(value), m_editable(editable), Node(loc) { }
-			VarDeclaration(std::shared_ptr<Node> type, std::shared_ptr<std::string> name, Location loc)
+			VarDeclaration(std::shared_ptr<TypeNode> type, std::shared_ptr<std::string> name, Location loc)
 				: m_type(type), m_name(name), m_value(nullptr), m_editable(true), Node(loc) { }
 		public:
-			inline std::shared_ptr<Node> GetType() { return m_type; }
+			inline std::shared_ptr<TypeNode> GetType() { return m_type; }
 			inline std::shared_ptr<Node> GetValue() { return m_value; }
 			inline std::shared_ptr<std::string> GetName() { return m_name; }
 			inline bool HasValue() { return m_value != nullptr; }

--- a/tmpl-script/include/parser.h
+++ b/tmpl-script/include/parser.h
@@ -51,6 +51,8 @@ namespace AST
 
     private: // Types
         std::shared_ptr<Nodes::TypeNode> Type();
+        std::shared_ptr<Nodes::TypeTemplateNode> TypeTemplate();
+        std::shared_ptr<Nodes::TypeDfNode> TypeDfStatement();
 
 	private: // Statements
 		std::shared_ptr<Node> Statement();

--- a/tmpl-script/include/parser.h
+++ b/tmpl-script/include/parser.h
@@ -1,5 +1,6 @@
 #ifndef PARSER_H
 #define PARSER_H
+#include "include/node/cast.h"
 #include "lexer.h"
 #include "node.h"
 #include "node/program.h"
@@ -46,6 +47,9 @@ namespace AST
 		std::shared_ptr<Node> Cond();
 		std::shared_ptr<Node> Ternary();
 
+    private: // Checkers
+        bool IsTypeCastAhead();
+
 	private: // Object Member
 		std::shared_ptr<Node> ObjectMember(std::shared_ptr<Node> obj);
 
@@ -53,6 +57,7 @@ namespace AST
         std::shared_ptr<Nodes::TypeNode> Type();
         std::shared_ptr<Nodes::TypeTemplateNode> TypeTemplate();
         std::shared_ptr<Nodes::TypeDfNode> TypeDfStatement();
+        std::shared_ptr<Nodes::CastNode> Cast(std::shared_ptr<Nodes::TypeNode> typ);
 
 	private: // Statements
 		std::shared_ptr<Node> Statement();

--- a/tmpl-script/include/parser.h
+++ b/tmpl-script/include/parser.h
@@ -6,6 +6,7 @@
 #include "node/identifier.h"
 #include "node/function.h"
 #include "node/list.h"
+#include "node/type.h"
 #include "error.h"
 #include <memory>
 
@@ -47,6 +48,9 @@ namespace AST
 
 	private: // Object Member
 		std::shared_ptr<Node> ObjectMember(std::shared_ptr<Node> obj);
+
+    private: // Types
+        std::shared_ptr<Nodes::TypeNode> Type();
 
 	private: // Statements
 		std::shared_ptr<Node> Statement();

--- a/tmpl-script/include/token.h
+++ b/tmpl-script/include/token.h
@@ -58,6 +58,7 @@ namespace AST
         TypeDf,
         Construct,
         New,
+        Cast,
 		_EOF,
 	};
 
@@ -113,6 +114,7 @@ namespace AST
         "typedf",
         "construct",
         "new",
+        "cast",
 		"EOF",
 	};
 

--- a/tmpl-script/include/token.h
+++ b/tmpl-script/include/token.h
@@ -56,6 +56,7 @@ namespace AST
         True,
         False,
         TypeDf,
+        Construct,
 		_EOF,
 	};
 
@@ -109,6 +110,7 @@ namespace AST
         "true",
         "false",
         "typedf",
+        "construct",
 		"EOF",
 	};
 

--- a/tmpl-script/include/token.h
+++ b/tmpl-script/include/token.h
@@ -57,6 +57,7 @@ namespace AST
         False,
         TypeDf,
         Construct,
+        New,
 		_EOF,
 	};
 
@@ -111,6 +112,7 @@ namespace AST
         "false",
         "typedf",
         "construct",
+        "new",
 		"EOF",
 	};
 

--- a/tmpl-script/include/token.h
+++ b/tmpl-script/include/token.h
@@ -55,6 +55,7 @@ namespace AST
         Extern,
         True,
         False,
+        TypeDf,
 		_EOF,
 	};
 
@@ -107,6 +108,7 @@ namespace AST
         "extern",
         "true",
         "false",
+        "typedf",
 		"EOF",
 	};
 

--- a/tmpl-script/include/typechecker.h
+++ b/tmpl-script/include/typechecker.h
@@ -123,7 +123,7 @@ namespace Runtime
 
 	public:
 		static PValType EvaluateType(std::string filename, std::shared_ptr<TypeNode> typeNode); // DONE
-        static PValType CastType(std::string filename, PValType from, PValType to, Location loc, TypeChecker::PTypeDfs typeDfs); // DONE
+        static PValType CastType(std::string filename, PValType from, PValType to, Location loc, TypeChecker::PTypeDfs typeDfs, std::string prefix); // DONE
 
     private:
         std::string GetFilename() const { return m_filename; }

--- a/tmpl-script/include/typechecker.h
+++ b/tmpl-script/include/typechecker.h
@@ -131,6 +131,7 @@ namespace Runtime
 	public:
 		static PValType EvaluateType(std::string filename, std::shared_ptr<TypeNode> typeNode); // DONE
         static PValType CastType(std::string filename, PValType from, PValType to, Location loc, TypeChecker::PTypeDfs typeDfs, std::string prefix); // DONE
+        static PValType GetRootType(std::string filename, PValType target, Location loc, TypeChecker::PTypeDfs typeDfs, std::string prefix);
 
     private:
         std::string GetFilename() const { return m_filename; }

--- a/tmpl-script/include/typechecker.h
+++ b/tmpl-script/include/typechecker.h
@@ -69,6 +69,7 @@ namespace Runtime
     class TypeChecker
     {
     public:
+        using TypeDfs = Environment<TypeDf>;
         using PTypeDfs = std::shared_ptr<Environment<TypeDf>>;
     private:
         std::shared_ptr<Parser> m_parser;
@@ -87,20 +88,20 @@ namespace Runtime
               m_functions(std::make_shared<Environment<TypeFn>>()),
               m_modules(std::make_shared<Environment<std::string>>()),
               m_type_functions(std::make_shared<Environment<Environment<TypeFn>, ValueType>>()),
+              m_type_definitions(std::make_shared<TypeDfs>()),
               m_errors(0) { }
     public:
         void RunChecker(std::shared_ptr<ProgramNode> program);
         void RunModuleChecker(std::shared_ptr<RequireMacro> require);
     private:
         PValType DiagnoseNode(std::shared_ptr<Node> node);
-        ValueType DiagnoseExpression(std::shared_ptr<ExpressionNode> expr);
-        ValueType DiagnoseLiteral(std::shared_ptr<LiteralNode> literal);
-        ValueType DiagnoseId(std::shared_ptr<IdentifierNode> identifier);
-        ValueType DiagnoseFnCall(std::shared_ptr<FunctionCall> fnCall);
-        ValueType DiagnoseUnary(std::shared_ptr<UnaryNode> unary);
-        ValueType DiagnoseCondition(std::shared_ptr<Condition> condition);
-        ValueType DiagnoseTernary(std::shared_ptr<TernaryNode> ternary);
-        // TODO:
+        PValType DiagnoseExpression(std::shared_ptr<ExpressionNode> expr);
+        PValType DiagnoseLiteral(std::shared_ptr<LiteralNode> literal);
+        PValType DiagnoseId(std::shared_ptr<IdentifierNode> identifier);
+        PValType DiagnoseFnCall(std::shared_ptr<FunctionCall> fnCall);
+        PValType DiagnoseUnary(std::shared_ptr<UnaryNode> unary);
+        PValType DiagnoseCondition(std::shared_ptr<Condition> condition);
+        PValType DiagnoseTernary(std::shared_ptr<TernaryNode> ternary);
 
     private:
         void HandleVarDeclaration(std::shared_ptr<VarDeclaration> varDecl);
@@ -110,8 +111,8 @@ namespace Runtime
         void HandleExportStatement(std::shared_ptr<ExportStatement> exportStmt);
 
     private:
-        void AssumeBlock(std::shared_ptr<Statements::StatementsBody> body, ValueType expected);
-        void AssumeIfElse(std::shared_ptr<Statements::IfElseStatement> ifElse, ValueType expected);
+        void AssumeBlock(std::shared_ptr<Statements::StatementsBody> body, PValType expected);
+        void AssumeIfElse(std::shared_ptr<Statements::IfElseStatement> ifElse, PValType expected);
 
     private:
         void ReportError() { m_errors++; };

--- a/tmpl-script/include/typechecker.h
+++ b/tmpl-script/include/typechecker.h
@@ -2,7 +2,9 @@
 #ifndef TYPECHECKER_H
 #define TYPECHECKER_H
 #include <memory>
+#include "include/helper.h"
 #include "include/interpreter.h"
+#include "include/node/cast.h"
 #include "include/node/instance.h"
 #include "include/node/logical.h"
 #include "include/node/type.h"
@@ -91,7 +93,7 @@ namespace Runtime
               m_functions(std::make_shared<Environment<TypeFn>>()),
               m_modules(std::make_shared<Environment<std::string>>()),
               m_type_functions(std::make_shared<Environment<Environment<TypeFn>>>()),
-              m_type_definitions(std::make_shared<TypeDfs>()),
+              m_type_definitions(Helper::Helper::GetTypeDefinitions()),
               m_errors(0) { }
     public:
         void RunChecker(std::shared_ptr<ProgramNode> program); // DONE
@@ -106,6 +108,7 @@ namespace Runtime
         PValType DiagnoseCondition(std::shared_ptr<Condition> condition); // DONE
         PValType DiagnoseTernary(std::shared_ptr<TernaryNode> ternary); // DONE
         PValType DiagnoseInstance(std::shared_ptr<InstanceNode> instance);
+        PValType DiagnoseTypeCasting(std::shared_ptr<CastNode> cast);
 
     private:
         void HandleVarDeclaration(std::shared_ptr<VarDeclaration> varDecl); // DONE

--- a/tmpl-script/include/typechecker.h
+++ b/tmpl-script/include/typechecker.h
@@ -17,6 +17,7 @@
 #include "node/statement.h"
 #include "node/var_declaration.h"
 #include "node/function.h"
+#include "node/type.h"
 
 namespace Runtime
 {
@@ -110,6 +111,7 @@ namespace Runtime
         void HandleFnSignature(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported); // DONE
         void HandleModule(std::shared_ptr<ProgramNode> program); // DONE
         void HandleExportStatement(std::shared_ptr<ExportStatement> exportStmt); // DONE
+        void HandleTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn);
 
     private:
         void AssumeBlock(std::shared_ptr<Statements::StatementsBody> body, PValType expected); // DONE

--- a/tmpl-script/include/typechecker.h
+++ b/tmpl-script/include/typechecker.h
@@ -6,6 +6,7 @@
 #include "include/node/logical.h"
 #include "include/node/type.h"
 #include "include/node/unary.h"
+#include "include/typechecker/typedf.h"
 #include "interpreter/environment.h"
 #include "interpreter/value.h"
 #include "parser.h"
@@ -67,6 +68,8 @@ namespace Runtime
 
     class TypeChecker
     {
+    public:
+        using PTypeDfs = std::shared_ptr<Environment<TypeDf>>;
     private:
         std::shared_ptr<Parser> m_parser;
         std::string m_filename;
@@ -74,6 +77,7 @@ namespace Runtime
         std::shared_ptr<Environment<TypeFn>> m_functions;
         std::shared_ptr<Environment<std::string>> m_modules;
         std::shared_ptr<Environment<Environment<TypeFn>, ValueType>> m_type_functions;
+        PTypeDfs m_type_definitions;
         int m_errors;
         
     public:
@@ -117,6 +121,7 @@ namespace Runtime
 
 	public:
 		static PValType EvaluateType(std::string filename, std::shared_ptr<TypeNode> typeNode);
+        static PValType CastType(std::string filename, PValType from, PValType to, PTypeDfs typeDfs);
 
     private:
         std::string GetFilename() const { return m_filename; }

--- a/tmpl-script/include/typechecker.h
+++ b/tmpl-script/include/typechecker.h
@@ -3,6 +3,7 @@
 #define TYPECHECKER_H
 #include <memory>
 #include "include/interpreter.h"
+#include "include/node/instance.h"
 #include "include/node/logical.h"
 #include "include/node/type.h"
 #include "include/node/unary.h"
@@ -104,6 +105,7 @@ namespace Runtime
         PValType DiagnoseUnary(std::shared_ptr<UnaryNode> unary); // DONE
         PValType DiagnoseCondition(std::shared_ptr<Condition> condition); // DONE
         PValType DiagnoseTernary(std::shared_ptr<TernaryNode> ternary); // DONE
+        PValType DiagnoseInstance(std::shared_ptr<InstanceNode> instance);
 
     private:
         void HandleVarDeclaration(std::shared_ptr<VarDeclaration> varDecl); // DONE

--- a/tmpl-script/include/typechecker.h
+++ b/tmpl-script/include/typechecker.h
@@ -116,7 +116,7 @@ namespace Runtime
         void HandleFnSignature(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported); // DONE
         void HandleModule(std::shared_ptr<ProgramNode> program); // DONE
         void HandleExportStatement(std::shared_ptr<ExportStatement> exportStmt); // DONE
-        void HandleTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn);
+        void HandleTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn, bool exported);
 
     private:
         void AssumeBlock(std::shared_ptr<Statements::StatementsBody> body, PValType expected); // DONE

--- a/tmpl-script/include/typechecker.h
+++ b/tmpl-script/include/typechecker.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include "include/interpreter.h"
 #include "include/node/logical.h"
+#include "include/node/type.h"
 #include "include/node/unary.h"
 #include "interpreter/environment.h"
 #include "interpreter/value.h"
@@ -23,13 +24,13 @@ namespace Runtime
     class TypeVariable
     {
     private:
-        ValueType m_type;
+        PValType m_type;
         bool m_editable;
     public:
-        TypeVariable(ValueType type, bool editable)
+        TypeVariable(PValType type, bool editable)
             : m_type(type), m_editable(editable) { }
     public:
-        inline ValueType GetType() const { return m_type; }
+        inline PValType GetType() const { return m_type; }
         inline bool IsEditable() const { return m_editable; }
     };
 
@@ -87,7 +88,7 @@ namespace Runtime
         void RunChecker(std::shared_ptr<ProgramNode> program);
         void RunModuleChecker(std::shared_ptr<RequireMacro> require);
     private:
-        ValueType DiagnoseNode(std::shared_ptr<Node> node);
+        PValType DiagnoseNode(std::shared_ptr<Node> node);
         ValueType DiagnoseExpression(std::shared_ptr<ExpressionNode> expr);
         ValueType DiagnoseLiteral(std::shared_ptr<LiteralNode> literal);
         ValueType DiagnoseId(std::shared_ptr<IdentifierNode> identifier);
@@ -115,7 +116,7 @@ namespace Runtime
         int GetErrorReport() { return m_errors; }
 
 	public:
-		static ValueType EvaluateType(std::string filename, std::shared_ptr<Node> typeNode);
+		static PValType EvaluateType(std::string filename, std::shared_ptr<TypeNode> typeNode);
 
     private:
         std::string GetFilename() const { return m_filename; }

--- a/tmpl-script/include/typechecker.h
+++ b/tmpl-script/include/typechecker.h
@@ -39,13 +39,13 @@ namespace Runtime
 	{
 	private:
         std::vector<std::shared_ptr<FnParam>> m_params;
-        ValueType m_ret_type;
+        PValType m_ret_type;
         std::string m_module_name;
         bool m_exported;
         Location m_loc;
 
 	public:
-		TypeFn(ValueType retType, std::string module, bool exported, Location loc)
+		TypeFn(PValType retType, std::string module, bool exported, Location loc)
 			: m_ret_type(retType),
             m_params(std::vector<std::shared_ptr<FnParam>>()),
             m_module_name(module),
@@ -60,7 +60,7 @@ namespace Runtime
             { return m_params[index]; }
         inline size_t GetParamsSize() const { return m_params.size(); }
     public:
-        inline ValueType GetReturnType() const { return m_ret_type; }
+        inline PValType GetReturnType() const { return m_ret_type; }
         inline std::string GetModuleName() const { return m_module_name; }
         inline bool IsExported() const { return m_exported; }
         inline Location GetLocation() const { return m_loc; }
@@ -77,7 +77,8 @@ namespace Runtime
         std::shared_ptr<Environment<TypeVariable>> m_variables;
         std::shared_ptr<Environment<TypeFn>> m_functions;
         std::shared_ptr<Environment<std::string>> m_modules;
-        std::shared_ptr<Environment<Environment<TypeFn>, ValueType>> m_type_functions;
+        // TODO: move inside type_definition
+        std::shared_ptr<Environment<Environment<TypeFn>>> m_type_functions;
         PTypeDfs m_type_definitions;
         int m_errors;
         
@@ -87,32 +88,32 @@ namespace Runtime
               m_variables(std::make_shared<Environment<TypeVariable>>()),
               m_functions(std::make_shared<Environment<TypeFn>>()),
               m_modules(std::make_shared<Environment<std::string>>()),
-              m_type_functions(std::make_shared<Environment<Environment<TypeFn>, ValueType>>()),
+              m_type_functions(std::make_shared<Environment<Environment<TypeFn>>>()),
               m_type_definitions(std::make_shared<TypeDfs>()),
               m_errors(0) { }
     public:
-        void RunChecker(std::shared_ptr<ProgramNode> program);
-        void RunModuleChecker(std::shared_ptr<RequireMacro> require);
+        void RunChecker(std::shared_ptr<ProgramNode> program); // DONE
+        void RunModuleChecker(std::shared_ptr<RequireMacro> require); // DONE
     private:
-        PValType DiagnoseNode(std::shared_ptr<Node> node);
-        PValType DiagnoseExpression(std::shared_ptr<ExpressionNode> expr);
-        PValType DiagnoseLiteral(std::shared_ptr<LiteralNode> literal);
-        PValType DiagnoseId(std::shared_ptr<IdentifierNode> identifier);
-        PValType DiagnoseFnCall(std::shared_ptr<FunctionCall> fnCall);
-        PValType DiagnoseUnary(std::shared_ptr<UnaryNode> unary);
-        PValType DiagnoseCondition(std::shared_ptr<Condition> condition);
-        PValType DiagnoseTernary(std::shared_ptr<TernaryNode> ternary);
+        PValType DiagnoseNode(std::shared_ptr<Node> node); // DONE
+        PValType DiagnoseExpression(std::shared_ptr<ExpressionNode> expr); // DONE
+        PValType DiagnoseLiteral(std::shared_ptr<LiteralNode> literal); // DONE
+        PValType DiagnoseId(std::shared_ptr<IdentifierNode> identifier); // DONE
+        PValType DiagnoseFnCall(std::shared_ptr<FunctionCall> fnCall); // DONE
+        PValType DiagnoseUnary(std::shared_ptr<UnaryNode> unary); // DONE
+        PValType DiagnoseCondition(std::shared_ptr<Condition> condition); // DONE
+        PValType DiagnoseTernary(std::shared_ptr<TernaryNode> ternary); // DONE
 
     private:
-        void HandleVarDeclaration(std::shared_ptr<VarDeclaration> varDecl);
-        void HandleFnDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported);
-        void HandleFnSignature(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported);
-        void HandleModule(std::shared_ptr<ProgramNode> program);
-        void HandleExportStatement(std::shared_ptr<ExportStatement> exportStmt);
+        void HandleVarDeclaration(std::shared_ptr<VarDeclaration> varDecl); // DONE
+        void HandleFnDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported); // DONE
+        void HandleFnSignature(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported); // DONE
+        void HandleModule(std::shared_ptr<ProgramNode> program); // DONE
+        void HandleExportStatement(std::shared_ptr<ExportStatement> exportStmt); // DONE
 
     private:
-        void AssumeBlock(std::shared_ptr<Statements::StatementsBody> body, PValType expected);
-        void AssumeIfElse(std::shared_ptr<Statements::IfElseStatement> ifElse, PValType expected);
+        void AssumeBlock(std::shared_ptr<Statements::StatementsBody> body, PValType expected); // DONE
+        void AssumeIfElse(std::shared_ptr<Statements::IfElseStatement> ifElse, PValType expected); // DONE
 
     private:
         void ReportError() { m_errors++; };
@@ -121,8 +122,8 @@ namespace Runtime
         int GetErrorReport() { return m_errors; }
 
 	public:
-		static PValType EvaluateType(std::string filename, std::shared_ptr<TypeNode> typeNode);
-        static PValType CastType(std::string filename, PValType from, PValType to, PTypeDfs typeDfs);
+		static PValType EvaluateType(std::string filename, std::shared_ptr<TypeNode> typeNode); // DONE
+        static PValType CastType(std::string filename, PValType from, PValType to, Location loc, TypeChecker::PTypeDfs typeDfs); // DONE
 
     private:
         std::string GetFilename() const { return m_filename; }

--- a/tmpl-script/include/typechecker/typedf.h
+++ b/tmpl-script/include/typechecker/typedf.h
@@ -30,19 +30,29 @@ namespace Runtime
     public:
         using Casts = Environment<TypeDfCast>;
         using PCasts = std::shared_ptr<Casts>;
+        using PFn = std::shared_ptr<Fn>;
     private:
         std::string m_typename;
-        std::string m_basename;
+        PValType m_basename;
         PCasts m_casts;
+        PFn m_constructor;
 
     public:
-        TypeDf(std::string tName, std::string basename)
-            : m_typename(tName), m_basename(basename), m_casts(std::make_shared<Casts>()) { }
+        TypeDf(std::string tName, PValType basename)
+            : m_typename(tName), m_basename(basename),
+              m_casts(std::make_shared<Casts>()),
+              m_constructor(nullptr) { }
     
     public:
         inline std::string GetTypeName() const { return m_typename; }
-        inline std::string GetBaseName() const { return m_basename; }
+        inline PValType GetBaseType() const { return m_basename; }
         inline PCasts GetCastsEnv() const { return m_casts; }
+
+        inline bool HasConstructor() const { return m_constructor != nullptr; }
+        inline PFn GetConstructor() const { return m_constructor; }
+
+    public:
+        void SetConstructor(PFn constructor) { m_constructor = constructor; }
     };
 }
 

--- a/tmpl-script/include/typechecker/typedf.h
+++ b/tmpl-script/include/typechecker/typedf.h
@@ -36,17 +36,26 @@ namespace Runtime
         PValType m_basename;
         PCasts m_casts;
         PFn m_constructor;
+        
+        std::string m_module;
+        bool m_exported;
+        AST::Location m_loc;
 
     public:
-        TypeDf(std::string tName, PValType basename)
+        TypeDf(std::string tName, PValType basename, std::string module, bool exported, AST::Location loc)
             : m_typename(tName), m_basename(basename),
               m_casts(std::make_shared<Casts>()),
-              m_constructor(nullptr) { }
+              m_constructor(nullptr),
+              m_exported(exported), m_module(module), m_loc(loc) { }
     
     public:
         inline std::string GetTypeName() const { return m_typename; }
         inline PValType GetBaseType() const { return m_basename; }
         inline PCasts GetCastsEnv() const { return m_casts; }
+
+        inline std::string GetModuleName() const { return m_module; }
+        inline bool IsExported() const { return m_exported; }
+        inline AST::Location GetLocation() const { return m_loc; }
 
         inline bool HasConstructor() const { return m_constructor != nullptr; }
         inline PFn GetConstructor() const { return m_constructor; }

--- a/tmpl-script/include/typechecker/typedf.h
+++ b/tmpl-script/include/typechecker/typedf.h
@@ -1,0 +1,49 @@
+#ifndef TYPECHECKER_TYPEDFN_H
+#define TYPECHECKER_TYPEDFN_H
+
+#include "include/interpreter/environment.h"
+#include<string>
+
+namespace Runtime
+{
+    class TypeDfCast
+    {
+    public:
+        using PFn = std::shared_ptr<Fn>;
+    private:
+        std::string m_origin; // cast from
+        std::string m_target; // cast to
+        PFn m_caster;
+
+    public:
+        TypeDfCast(std::string origin, std::string target, PFn caster)
+            : m_origin(origin), m_target(target), m_caster(caster) { }
+
+    public:
+        inline std::string GetOrigin() const { return m_origin; }
+        inline std::string GetTarget() const { return m_target; }
+        inline PFn GetCaster() const { return m_caster; }
+    };
+
+    class TypeDf
+    {
+    public:
+        using Casts = Environment<TypeDfCast>;
+        using PCasts = std::shared_ptr<Casts>;
+    private:
+        std::string m_typename;
+        std::string m_basename;
+        PCasts m_casts;
+
+    public:
+        TypeDf(std::string tName, std::string basename)
+            : m_typename(tName), m_basename(basename), m_casts(std::make_shared<Casts>()) { }
+    
+    public:
+        inline std::string GetTypeName() const { return m_typename; }
+        inline std::string GetBaseName() const { return m_basename; }
+        inline PCasts GetCastsEnv() const { return m_casts; }
+    };
+}
+
+#endif // TYPECHECKER_TYPEDFN_H

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -178,7 +178,7 @@ namespace Prelude
     void ErrorManager::TypeCastNotPossible(std::string filename, Runtime::PValType from, Runtime::PValType to, AST::Location loc, std::string prefix)
     {
         LogFileLocation(filename, loc, prefix);
-        std::cerr << "Type '" << *from << "' cannot be converted to type '"
+        std::cerr << "Type '" << *from << "' cannot be casted to type '"
             << *to << "'" << std::endl;
         if (prefix != "TypeError") exit(-1);
     }

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -290,6 +290,14 @@ namespace Prelude
         if (prefix != "TypeError") std::exit(-1);
     }
 
+    void ErrorManager::TypeCastRedeclaration(std::string filename, std::string typeName, Runtime::PValType castType, AST::Location loc, std::string prefix)
+    {
+        LogFileLocation(filename, loc, prefix);
+        std::cerr << "Cast '" << typeName << "' -> '" << *castType
+            << "' already exists" << std::endl;
+        if (prefix != "TypeError") std::exit(-1);
+    }
+
     void ErrorManager::FunctionRedeclaration(std::string filename, std::string name, AST::Location loc, std::string declFilename, AST::Location declLoc, std::string prefix)
     {
         LogFileLocation(filename, loc, prefix);

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -308,6 +308,16 @@ namespace Prelude
         if (prefix != "TypeError") std::exit(-1);
     }
 
+    void ErrorManager::PrivateTypeError(std::string filename, std::string typName, std::string typModule, AST::Location loc, AST::Location mLoc, std::string prefix)
+    {
+        LogFileLocation(filename, loc, prefix);
+        std::cerr << "Trying to access a private type '" << typName
+            << "' outside of it's module ";
+        LogFileLocation(typModule, mLoc);
+        std::cerr << std::endl;
+        if (prefix != "TypeError") std::exit(-1);
+    }
+
     void ErrorManager::PrivateFunctionError(std::string filename, std::string fnName, std::string fnModule, Location loc, Location mLoc, std::string prefix)
     {
         LogFileLocation(filename, loc, prefix);

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -75,6 +75,13 @@ namespace Prelude
         std::cerr << "Expected '" << Token::GetTokenTypeCharacter(expectedTokenType) << "' but got '" << Token::GetTokenTypeCharacter(gotToken->GetType()) << "'" << std::endl;
 		std::exit(-1);
 	}
+    void ErrorManager::UnexpectedFnModifier(std::string filename, std::shared_ptr<AST::Token> gotToken, AST::Location loc)
+    {
+        LogFileLocation(filename, loc, "ParseError");
+        std::cerr << "Unexpected token used for fn modifier '"
+            << Token::GetTokenTypeCharacter(gotToken->GetType()) << "'" << std::endl;
+		std::exit(-1);
+    }
 	void ErrorManager::MissingConstantDefinition(std::string filename, std::shared_ptr<Token> token)
 	{
         LogFileLocation(filename, token->GetLocation(), "ParseError");

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -82,13 +82,13 @@ namespace Prelude
 				  << "but got unexpected '" << Token::GetTokenTypeCharacter(token->GetType()) << "'" << std::endl;
 		std::exit(-1);
 	}
-	void ErrorManager::VarMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc, std::string prefix)
+	void ErrorManager::VarMismatchType(std::string filename, std::string name, Runtime::PValType type, Runtime::PValType expectedType, Location loc, std::string prefix)
 	{
         // TODO: allow defining double type variable with float value (casting) and opposite direction
         LogFileLocation(filename, loc, prefix);
         std::cerr << "Type mismatch for variable '" << name
-            << "'. Expected type '" << Runtime::HumanValueType(expectedType)
-            << "' but got '" << Runtime::HumanValueType(type) << "'" << std::endl;
+            << "'. Expected type '" << expectedType
+            << "' but got '" << type << "'" << std::endl;
         if (prefix != "TypeError") std::exit(-1);
 	}
 	void ErrorManager::OperandMismatchType(std::string filename, Runtime::ValueType leftType, Runtime::ValueType rightType, Location loc, std::string prefix)

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -161,6 +161,20 @@ namespace Prelude
         if (prefix != "TypeError") exit(-1);
     }
 
+    void ErrorManager::TypeDoesNotExist(std::string filename, std::string typName, AST::Location loc, std::string prefix)
+    {
+        LogFileLocation(filename, loc, prefix);
+        std::cerr << "Type with name '" << typName << "' is not defined" << std::endl;
+        if (prefix != "TypeError") exit(-1);
+    }
+
+    void ErrorManager::TypeConstructorDoesNotExist(std::string filename, Runtime::PValType targetTyp, AST::Location loc, std::string prefix)
+    {
+        LogFileLocation(filename, loc, prefix);
+        std::cerr << "No constructor found for type '" << *targetTyp << "'" << std::endl;
+        if (prefix != "TypeError") exit(-1);
+    }
+
     void ErrorManager::TypeCastNotPossible(std::string filename, Runtime::PValType from, Runtime::PValType to, AST::Location loc, std::string prefix)
     {
         LogFileLocation(filename, loc, prefix);
@@ -264,6 +278,15 @@ namespace Prelude
         // TODO: show generics as well
         std::cerr << "Cannot redeclare already existing type '"
             << typeNode->GetTypeName()->GetName() << "'" << std::endl;
+        if (prefix != "TypeError") std::exit(-1);
+    }
+
+    void ErrorManager::TypeConstructorRedeclaration(std::string filename, std::string typeName, AST::Location loc, std::string prefix)
+    {
+        LogFileLocation(filename, loc, prefix);
+        // TODO: show generics as well
+        std::cerr << "Cannot redeclare type constructor for '"
+            << typeName << "'" << std::endl;
         if (prefix != "TypeError") std::exit(-1);
     }
 

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -91,10 +91,10 @@ namespace Prelude
             << "' but got '" << *type << "'" << std::endl;
         if (prefix != "TypeError") std::exit(-1);
 	}
-	void ErrorManager::OperandMismatchType(std::string filename, Runtime::ValueType leftType, Runtime::ValueType rightType, Location loc, std::string prefix)
+	void ErrorManager::OperandMismatchType(std::string filename, Runtime::PValType leftType, Runtime::PValType rightType, Location loc, std::string prefix)
 	{
         LogFileLocation(filename, loc, prefix);
-        std::cerr << "Mismatch type of left and right operands '" << Runtime::HumanValueType(leftType) << "' != '" << Runtime::HumanValueType(rightType) << "'" << std::endl;
+        std::cerr << "Mismatch type of left and right operands '" << *leftType << "' != '" << *rightType << "'" << std::endl;
         if (prefix != "TypeError") std::exit(-1);
 	}
 	void ErrorManager::UndefinedType(std::string filename, std::string name, Location loc, std::string prefix)
@@ -110,13 +110,13 @@ namespace Prelude
         std::cerr << "Undeclared variable '" << id->GetName() << "'" << std::endl;
         if (prefix != "TypeError") std::exit(-1);
 	}
-    void ErrorManager::ArgMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc, std::string prefix)
+    void ErrorManager::ArgMismatchType(std::string filename, std::string name, Runtime::PValType type, Runtime::PValType expectedType, Location loc, std::string prefix)
     {
         LogFileLocation(filename, loc, prefix);
         std::cerr << "Argument type '"
-            << Runtime::HumanValueType(type)
+            << *type
             << "' of parameter '" << name << "' doesn't match parameter type '"
-            << Runtime::HumanValueType(expectedType)
+            << *expectedType
             << "'" << std::endl;
         if (prefix != "TypeError") exit(-1);
     }
@@ -132,31 +132,31 @@ namespace Prelude
         exit(-1);
     }
 
-    void ErrorManager::UnexpectedReturnType(std::string filename, Runtime::ValueType expected, Runtime::ValueType gotType, Location loc)
+    void ErrorManager::UnexpectedReturnType(std::string filename, Runtime::PValType expected, Runtime::PValType gotType, Location loc)
     {
         LogFileLocation(filename, loc, "TypeError");
-        std::cerr << "Unexpected return type '" << Runtime::HumanValueType(gotType) << "' when '" << Runtime::HumanValueType(expected) << "' type was expected" << std::endl;
+        std::cerr << "Unexpected return type '" << *gotType << "' when '" << *expected << "' type was expected" << std::endl;
         /*exit(-1);*/
     }
 
-    void ErrorManager::TypeMismatch(std::string filename, Runtime::ValueType left, Runtime::ValueType right, Location loc)
+    void ErrorManager::TypeMismatch(std::string filename, Runtime::PValType left, Runtime::PValType right, Location loc)
     {
         LogFileLocation(filename, loc, "TypeError");
-        std::cerr << "Different return types '" << Runtime::HumanValueType(left)
-            << "' and '" << Runtime::HumanValueType(right) << "'" << std::endl;
+        std::cerr << "Different return types '" << *left
+            << "' and '" << *right << "'" << std::endl;
         /*exit(-1);*/
     }
 
-    void ErrorManager::TypeDoesNotExist(std::string filename, Runtime::PValType typ, std::string prefix)
+    void ErrorManager::TypeDoesNotExist(std::string filename, Runtime::PValType typ, AST::Location loc, std::string prefix)
     {
-        LogFileLocation(filename, typ->GetLocation(), prefix);
+        LogFileLocation(filename, loc, prefix);
         std::cerr << "Type '" << *typ << "' is not defined" << std::endl;
         if (prefix != "TypeError") exit(-1);
     }
 
-    void ErrorManager::TypeCastNotPossible(std::string filename, Runtime::PValType from, Runtime::PValType to, std::string prefix)
+    void ErrorManager::TypeCastNotPossible(std::string filename, Runtime::PValType from, Runtime::PValType to, AST::Location loc, std::string prefix)
     {
-        LogFileLocation(filename, from->GetLocation(), prefix);
+        LogFileLocation(filename, loc, prefix);
         std::cerr << "Type '" << *from << "' cannot be converted to type '"
             << *to << "'" << std::endl;
         if (prefix != "TypeError") exit(-1);

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -87,8 +87,8 @@ namespace Prelude
         // TODO: allow defining double type variable with float value (casting) and opposite direction
         LogFileLocation(filename, loc, prefix);
         std::cerr << "Type mismatch for variable '" << name
-            << "'. Expected type '" << expectedType
-            << "' but got '" << type << "'" << std::endl;
+            << "'. Expected type '" << *expectedType
+            << "' but got '" << *type << "'" << std::endl;
         if (prefix != "TypeError") std::exit(-1);
 	}
 	void ErrorManager::OperandMismatchType(std::string filename, Runtime::ValueType leftType, Runtime::ValueType rightType, Location loc, std::string prefix)
@@ -145,6 +145,21 @@ namespace Prelude
         std::cerr << "Different return types '" << Runtime::HumanValueType(left)
             << "' and '" << Runtime::HumanValueType(right) << "'" << std::endl;
         /*exit(-1);*/
+    }
+
+    void ErrorManager::TypeDoesNotExist(std::string filename, Runtime::PValType typ, std::string prefix)
+    {
+        LogFileLocation(filename, typ->GetLocation(), prefix);
+        std::cerr << "Type '" << *typ << "' is not defined" << std::endl;
+        if (prefix != "TypeError") exit(-1);
+    }
+
+    void ErrorManager::TypeCastNotPossible(std::string filename, Runtime::PValType from, Runtime::PValType to, std::string prefix)
+    {
+        LogFileLocation(filename, from->GetLocation(), prefix);
+        std::cerr << "Type '" << *from << "' cannot be converted to type '"
+            << *to << "'" << std::endl;
+        if (prefix != "TypeError") exit(-1);
     }
 
     void ErrorManager::ArgsParamsExhausted(std::string filename, std::string name, size_t argsSize, size_t paramsSize, Location loc, std::string prefix)

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -250,15 +250,25 @@ namespace Prelude
         if (prefix != "TypeError") std::exit(-1);
     }
 
-        void ErrorManager::FunctionRedeclaration(std::string filename, std::string name, AST::Location loc, std::string declFilename, AST::Location declLoc, std::string prefix)
-        {
-            LogFileLocation(filename, loc, prefix);
-            std::cerr << "Cannot redeclare already existing function '"
-                << name << "' at ";
-            LogFileLocation(declFilename, declLoc);
-            std::cerr << std::endl;
-            if (prefix != "TypeError") std::exit(-1);
-        }
+
+    void ErrorManager::TypeRedeclaration(std::string filename, std::shared_ptr<AST::Nodes::TypeTemplateNode> typeNode, std::string prefix)
+    {
+        LogFileLocation(filename, typeNode->GetLocation(), prefix);
+        // TODO: show generics as well
+        std::cerr << "Cannot redeclare already existing type '"
+            << typeNode->GetTypeName()->GetName() << "'" << std::endl;
+        if (prefix != "TypeError") std::exit(-1);
+    }
+
+    void ErrorManager::FunctionRedeclaration(std::string filename, std::string name, AST::Location loc, std::string declFilename, AST::Location declLoc, std::string prefix)
+    {
+        LogFileLocation(filename, loc, prefix);
+        std::cerr << "Cannot redeclare already existing function '"
+            << name << "' at ";
+        LogFileLocation(declFilename, declLoc);
+        std::cerr << std::endl;
+        if (prefix != "TypeError") std::exit(-1);
+    }
 
     void ErrorManager::PrivateFunctionError(std::string filename, std::string fnName, std::string fnModule, Location loc, Location mLoc, std::string prefix)
     {

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -121,13 +121,13 @@ namespace Prelude
         if (prefix != "TypeError") exit(-1);
     }
 
-    void ErrorManager::ReturnMismatchType(std::string filename, std::string name, Runtime::ValueType type, Runtime::ValueType expectedType, Location loc)
+    void ErrorManager::ReturnMismatchType(std::string filename, std::string name, Runtime::PValType type, Runtime::PValType expectedType, Location loc)
     {
         LogFileLocation(filename, loc, "RuntimeError");
         std::cerr << "Return value type '"
-            << Runtime::HumanValueType(type)
+            << *type
             << "' of the function '" << name << "' doesn't match function's signature type '"
-            << Runtime::HumanValueType(expectedType)
+            << *expectedType
             << "'" << std::endl;
         exit(-1);
     }
@@ -180,11 +180,11 @@ namespace Prelude
         if (prefix != "TypeError") exit(-1);
     }
 
-    void ErrorManager::UnaryOperatorNotSupported(std::string filename, std::string op, Runtime::ValueType metType, Location loc)
+    void ErrorManager::UnaryOperatorNotSupported(std::string filename, std::string op, Runtime::PValType metType, Location loc)
     {
         LogFileLocation(filename, loc, "RuntimeError");
         std::cerr << "Unary operator '" << op
-            << "' is not allowed with type '" << Runtime::HumanValueType(metType) << "'" << std::endl;
+            << "' is not allowed with type '" << *metType << "'" << std::endl;
         std::exit(-1);
     }
 
@@ -196,13 +196,13 @@ namespace Prelude
         if (prefix != "TypeError") std::exit(-1);
     }
 
-    void ErrorManager::UndeclaredFunction(std::string filename, std::shared_ptr<AST::Nodes::ObjectMember> obj, Runtime::ValueType valType, std::string prefix)
+    void ErrorManager::UndeclaredFunction(std::string filename, std::shared_ptr<AST::Nodes::ObjectMember> obj, Runtime::PValType valType, std::string prefix)
     {
         auto loc = obj->GetLocation();
         LogFileLocation(filename, loc, prefix);
         assert(obj->GetMember()->GetType() == NodeType::Identifier && "Object member for fn call should be an identifier.");
         auto id = std::dynamic_pointer_cast<Nodes::IdentifierNode>(obj->GetMember());
-        std::cerr << "Calling undeclared function '" << id->GetName() << "' for type '" << Runtime::HumanValueType(valType) << "'" << std::endl;
+        std::cerr << "Calling undeclared function '" << id->GetName() << "' for type '" << *valType << "'" << std::endl;
         if (prefix != "TypeError") std::exit(-1);
     }
 

--- a/tmpl-script/src/helper.cpp
+++ b/tmpl-script/src/helper.cpp
@@ -1,17 +1,18 @@
 
 #include "include/helper.h"
 #include "include/interpreter/value.h"
+#include "include/location.h"
 #include "include/typechecker/typedf.h"
 
 namespace Helper
 {
     void Helper::DefineBuiltInType(std::string builtinName, std::string name, PTypeDfEnv env)
     {
-        auto bTypeDf = std::make_shared<Runtime::TypeDf>(builtinName, nullptr);
+        auto bTypeDf = std::make_shared<Runtime::TypeDf>(builtinName, nullptr, "#GLOBAL", true, AST::Location(-1, -1));
         auto bType = std::make_shared<Runtime::ValType>(builtinName);
         env->AddItem(builtinName, bTypeDf);
 
-        auto Type = std::make_shared<Runtime::TypeDf>(name, bType);
+        auto Type = std::make_shared<Runtime::TypeDf>(name, bType, "#GLOBAL", true, AST::Location(-1, -1));
         env->AddItem(name, Type);
     }
 

--- a/tmpl-script/src/helper.cpp
+++ b/tmpl-script/src/helper.cpp
@@ -5,18 +5,26 @@
 
 namespace Helper
 {
+    void Helper::DefineBuiltInType(std::string builtinName, std::string name, PTypeDfEnv env)
+    {
+        auto bTypeDf = std::make_shared<Runtime::TypeDf>(builtinName, nullptr);
+        auto bType = std::make_shared<Runtime::ValType>(builtinName);
+        env->AddItem(builtinName, bTypeDf);
+
+        auto Type = std::make_shared<Runtime::TypeDf>(name, bType);
+        env->AddItem(name, Type);
+    }
+
     Helper::PTypeDfEnv Helper::GetTypeDefinitions()
     {
         auto typeDefinitions = std::make_shared<Helper::TypeDfEnv>();
 
-        std::string bIntName = "#BUILTIN_INT";
-
-        auto bInt = std::make_shared<Runtime::TypeDf>(bIntName, nullptr);
-        auto bIntType = std::make_shared<Runtime::ValType>(bIntName);
-        typeDefinitions->AddItem(bIntName, bInt);
-
-        auto Int = std::make_shared<Runtime::TypeDf>("int", bIntType);
-        typeDefinitions->AddItem("int", Int);
+        DefineBuiltInType("#BUILTIN_INT", "int", typeDefinitions);
+        DefineBuiltInType("#BUILTIN_FLOAT", "float", typeDefinitions);
+        DefineBuiltInType("#BUILTIN_DOUBLE", "double", typeDefinitions);
+        DefineBuiltInType("#BUILTIN_STRING", "string", typeDefinitions);
+        DefineBuiltInType("#BUILTIN_BOOL", "bool", typeDefinitions);
+        // TODO: list type
 
         return typeDefinitions;
     }

--- a/tmpl-script/src/helper.cpp
+++ b/tmpl-script/src/helper.cpp
@@ -1,0 +1,24 @@
+
+#include "include/helper.h"
+#include "include/interpreter/value.h"
+#include "include/typechecker/typedf.h"
+
+namespace Helper
+{
+    Helper::PTypeDfEnv Helper::GetTypeDefinitions()
+    {
+        auto typeDefinitions = std::make_shared<Helper::TypeDfEnv>();
+
+        std::string bIntName = "#BUILTIN_INT";
+
+        auto bInt = std::make_shared<Runtime::TypeDf>(bIntName, nullptr);
+        auto bIntType = std::make_shared<Runtime::ValType>(bIntName);
+        typeDefinitions->AddItem(bIntName, bInt);
+
+        auto Int = std::make_shared<Runtime::TypeDf>("int", bIntType);
+        typeDefinitions->AddItem("int", Int);
+
+        return typeDefinitions;
+    }
+}
+

--- a/tmpl-script/src/interpreter.cpp
+++ b/tmpl-script/src/interpreter.cpp
@@ -140,6 +140,8 @@ namespace Runtime
             return EvaluateIfElseStatement(std::dynamic_pointer_cast<Statements::IfElseStatement>(node));
         case NodeType::Instance:
             return EvaluateInstance(std::dynamic_pointer_cast<InstanceNode>(node));
+        case NodeType::Cast:
+            return EvaluateTypeCasting(std::dynamic_pointer_cast<CastNode>(node));
         case NodeType::Block:
         {
             auto block = std::dynamic_pointer_cast<Statements::StatementsNode>(node);

--- a/tmpl-script/src/interpreter.cpp
+++ b/tmpl-script/src/interpreter.cpp
@@ -59,6 +59,9 @@ namespace Runtime
                 case NodeType::ProcedureDecl:
                     EvaluateProcedureDeclaration(std::dynamic_pointer_cast<ProcedureDeclaration>(stmt));
                     break;
+                case NodeType::TypeDf:
+                    EvaluateTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(stmt));
+                    break;
                 case NodeType::Export:
                     // Ignore export in the tmpl executable
                     break;
@@ -95,6 +98,9 @@ namespace Runtime
                 }
                 case NodeType::FnDecl:
                     EvaluateFunctionDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt), true, false);
+                    break;
+                case NodeType::TypeDf:
+                    EvaluateTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(stmt));
                     break;
                 default:
                     {

--- a/tmpl-script/src/interpreter.cpp
+++ b/tmpl-script/src/interpreter.cpp
@@ -1,4 +1,5 @@
 
+#include "include/node/instance.h"
 #include <cassert>
 #include <memory>
 #ifdef _WIN32
@@ -137,6 +138,8 @@ namespace Runtime
             return EvaluateFunctionCall(std::dynamic_pointer_cast<FunctionCall>(node));
         case NodeType::IfElse:
             return EvaluateIfElseStatement(std::dynamic_pointer_cast<Statements::IfElseStatement>(node));
+        case NodeType::Instance:
+            return EvaluateInstance(std::dynamic_pointer_cast<InstanceNode>(node));
         case NodeType::Block:
         {
             auto block = std::dynamic_pointer_cast<Statements::StatementsNode>(node);

--- a/tmpl-script/src/interpreter.cpp
+++ b/tmpl-script/src/interpreter.cpp
@@ -59,6 +59,9 @@ namespace Runtime
                 case NodeType::ProcedureDecl:
                     EvaluateProcedureDeclaration(std::dynamic_pointer_cast<ProcedureDeclaration>(stmt));
                     break;
+                case NodeType::Export:
+                    // Ignore export in the tmpl executable
+                    break;
                 default:
                     {
                         Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
@@ -147,7 +150,7 @@ namespace Runtime
                 else
                 {
                     auto localVal = Execute(node);
-                    if (node->IsBlock() && (localVal != nullptr && localVal->GetType() != ValueType::Null))
+                    if (node->IsBlock() && (localVal != nullptr && !localVal->GetType()->Compare(ValType("void"))))
                     {
                         value = localVal;
                         break;

--- a/tmpl-script/src/interpreter.cpp
+++ b/tmpl-script/src/interpreter.cpp
@@ -61,7 +61,7 @@ namespace Runtime
                     EvaluateProcedureDeclaration(std::dynamic_pointer_cast<ProcedureDeclaration>(stmt));
                     break;
                 case NodeType::TypeDf:
-                    EvaluateTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(stmt));
+                    EvaluateTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(stmt), false);
                     break;
                 case NodeType::Export:
                     // Ignore export in the tmpl executable
@@ -101,7 +101,7 @@ namespace Runtime
                     EvaluateFunctionDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt), true, false);
                     break;
                 case NodeType::TypeDf:
-                    EvaluateTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(stmt));
+                    EvaluateTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(stmt), false);
                     break;
                 default:
                     {

--- a/tmpl-script/src/interpreter.cpp
+++ b/tmpl-script/src/interpreter.cpp
@@ -116,7 +116,7 @@ namespace Runtime
 			return EvaluateLiteral(std::dynamic_pointer_cast<LiteralNode>(node));
 		case NodeType::VarDecl:
 			EvaluateVariableDeclaration(std::dynamic_pointer_cast<VarDeclaration>(node));
-			return std::make_shared<NullValue>();
+			return std::make_shared<VoidValue>();
 		case NodeType::Identifier:
 			return EvaluateIdentifier(std::dynamic_pointer_cast<IdentifierNode>(node));
 		case NodeType::Condition:
@@ -136,7 +136,7 @@ namespace Runtime
             auto block = std::dynamic_pointer_cast<Statements::StatementsNode>(node);
             auto scope = std::make_shared<Environment<Variable>>(m_variables);
             m_variables = scope;
-            std::shared_ptr<Value> value = std::make_shared<NullValue>();
+            std::shared_ptr<Value> value = std::make_shared<VoidValue>();
             auto it = std::make_shared<Common::Iterator>(block->GetSize());
             while (it->HasItems())
             {
@@ -170,6 +170,6 @@ namespace Runtime
             }
 		}
 
-		return std::make_shared<NullValue>();
+		return std::make_shared<VoidValue>();
 	}
 }

--- a/tmpl-script/src/interpreter/cast.cpp
+++ b/tmpl-script/src/interpreter/cast.cpp
@@ -1,0 +1,19 @@
+
+#include "include/interpreter.h"
+#include "include/typechecker.h"
+
+namespace Runtime
+{
+    std::shared_ptr<Value> Interpreter::EvaluateTypeCasting(std::shared_ptr<CastNode> cast)
+    {
+        auto target = Execute(cast->GetExpr());
+        auto targetType = TypeChecker::EvaluateType(GetFilename(), cast->GetTypeNode());
+
+        TypeChecker::CastType(GetFilename(), target->GetType(), targetType, cast->GetTypeNode()->GetLocation(), m_type_definitions, "TypeError");
+
+        target->SetType(targetType);
+
+        return target;
+    }
+}
+

--- a/tmpl-script/src/interpreter/cast.cpp
+++ b/tmpl-script/src/interpreter/cast.cpp
@@ -9,11 +9,9 @@ namespace Runtime
         auto target = Execute(cast->GetExpr());
         auto targetType = TypeChecker::EvaluateType(GetFilename(), cast->GetTypeNode());
 
-        TypeChecker::CastType(GetFilename(), target->GetType(), targetType, cast->GetTypeNode()->GetLocation(), m_type_definitions, "TypeError");
+        auto clonedValue = target->Clone();
 
-        target->SetType(targetType);
-
-        return target;
+        return CastValue(clonedValue, targetType, cast->GetTypeNode()->GetLocation());
     }
 }
 

--- a/tmpl-script/src/interpreter/expr.cpp
+++ b/tmpl-script/src/interpreter/expr.cpp
@@ -1,5 +1,6 @@
 
 #include "../../include/interpreter.h"
+#include "include/typechecker.h"
 #include <memory>
 #include <cassert>
 
@@ -18,17 +19,18 @@ namespace Runtime
 
         if (unary->GetOperator() == UnaryNode::UnaryOperator::Negative)
         {
-            if (target->GetType()->Compare(ValType("int")))
+            auto rootTyp = TypeChecker::GetRootType(GetFilename(), target->GetType(), unary->GetTarget()->GetLocation(), m_type_definitions, "RuntimeError");
+            if (rootTyp->Compare(ValType("#BUILTIN_INT")))
             {
                 std::shared_ptr<IntegerValue> val = std::dynamic_pointer_cast<IntegerValue>(target);
                 return std::make_shared<IntegerValue>(std::make_shared<int>(-(*val->GetValue())));
             }
-            if (target->GetType()->Compare(ValType("float")))
+            if (rootTyp->Compare(ValType("#BUILTIN_FLOAT")))
             {
                 std::shared_ptr<FloatValue> val = std::dynamic_pointer_cast<FloatValue>(target);
                 return std::make_shared<FloatValue>(std::make_shared<float>(-(*val->GetValue())));
             }
-            if (target->GetType()->Compare(ValType("double")))
+            if (rootTyp->Compare(ValType("#BUILTIN_DOUBLE")))
             {
                 std::shared_ptr<DoubleValue> val = std::dynamic_pointer_cast<DoubleValue>(target);
                 return std::make_shared<DoubleValue>(std::make_shared<double>(-(*val->GetValue())));

--- a/tmpl-script/src/interpreter/fn_call.cpp
+++ b/tmpl-script/src/interpreter/fn_call.cpp
@@ -31,15 +31,15 @@ namespace Runtime
             {
                 auto obj = std::dynamic_pointer_cast<ObjectMember>(callee);
                 std::shared_ptr<Value> targetVal = Execute(obj->GetObject());
-                ValueType targetType = targetVal->GetType();
-                if (!m_type_functions->HasItem(targetType))
+                PValType targetType = targetVal->GetType();
+                if (!m_type_functions->HasItem(targetType->GetName()))
                 {
                     Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
                     errManager.UndeclaredFunction(GetFilename(), obj, targetType, "RuntimeError");
                     return nullptr;
                 }
 
-                std::shared_ptr<Environment<Fn>> typeEnv = m_type_functions->LookUp(targetType);
+                std::shared_ptr<Environment<Fn>> typeEnv = m_type_functions->LookUp(targetType->GetName());
                 assert(typeEnv != nullptr && "Type env should have been created.");
 
                 std::shared_ptr<Node> fnNameNode = obj->GetMember();
@@ -112,7 +112,7 @@ namespace Runtime
             std::shared_ptr<Node> arg = (*args)[it->GetPosition()];
             it->Next();
             std::shared_ptr<Value> val = Execute(arg);
-            if (val->GetType() != param->GetType())
+            if (!val->GetType()->Compare(*param->GetType()))
             {
                 Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
                 errorManager.ArgMismatchType(
@@ -145,7 +145,7 @@ namespace Runtime
             m_variables = currentScope;
             SetFilename(currentModule);
 
-            if (value->GetType() != fn->GetReturnType())
+            if (!value->GetType()->Compare(*fn->GetReturnType()))
             {
                 Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
                 errorManager.ReturnMismatchType(GetFilename(), fnName, value->GetType(), fn->GetReturnType(), fnCall->GetLocation());

--- a/tmpl-script/src/interpreter/fn_decl.cpp
+++ b/tmpl-script/src/interpreter/fn_decl.cpp
@@ -51,6 +51,13 @@ namespace Runtime
                 auto typeDf = m_type_definitions->LookUp(typeName);
                 assert(typeDf != nullptr && "Type df shouldn't be null at this point.");
 
+                if (GetFilename() != typeDf->GetModuleName() && !typeDf->IsExported())
+                {
+                    Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+                    errorManager.PrivateTypeError(GetFilename(), typeDf->GetTypeName(), typeDf->GetModuleName(), nameNode->GetLocation(), typeDf->GetLocation(), "RuntimeError");
+                    return;
+                }
+
                 // TODO: compare generics amount and names
                 if (typeDf->HasConstructor())
                 {
@@ -84,6 +91,13 @@ namespace Runtime
 
                 auto typeDf = m_type_definitions->LookUp(typeName);
                 assert(typeDf != nullptr && "Type df shouldn't be null at this point.");
+
+                if (GetFilename() != typeDf->GetModuleName() && !typeDf->IsExported())
+                {
+                    Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+                    errorManager.PrivateTypeError(GetFilename(), typeDf->GetTypeName(), typeDf->GetModuleName(), nameNode->GetLocation(), typeDf->GetLocation(), "RuntimeError");
+                    return;
+                }
 
                 auto casts = typeDf->GetCastsEnv();
 

--- a/tmpl-script/src/interpreter/fn_extern_call.cpp
+++ b/tmpl-script/src/interpreter/fn_extern_call.cpp
@@ -68,50 +68,44 @@ namespace Runtime
             std::shared_ptr<Node> arg = (*args)[it->GetPosition()];
             it->Next();
             std::shared_ptr<Value> val = Execute(arg);
-            switch(val->GetType()) {
-                case ValueType::String:
-                {
-                    auto sVal = std::dynamic_pointer_cast<StringValue>(val);
+            auto valType = val->GetType();
+            if (valType->Compare(ValType("string")))
+            {
+                auto sVal = std::dynamic_pointer_cast<StringValue>(val);
 #ifdef _WIN32
-                    char* str = _strdup(sVal->GetValue()->c_str());
+                char* str = _strdup(sVal->GetValue()->c_str());
 #else
-                    char* str = strdup(sVal->GetValue()->c_str());
+                char* str = strdup(sVal->GetValue()->c_str());
 #endif
-                    data[it->GetPosition() - 1] = (void*)str;
-                    break;
-                }
-                case ValueType::Bool:
-                {
-                    auto bVal = std::dynamic_pointer_cast<BoolValue>(val);
-                    int* b = new int(bVal->GetValue() ? 1 : 0);
-                    data[it->GetPosition() - 1] = (void*)b;
-                    break;
-                }
-                case ValueType::Float:
-                {
-                    auto fVal = std::dynamic_pointer_cast<FloatValue>(val);
-                    float* b = new float(*fVal->GetValue());
-                    data[it->GetPosition() - 1] = (void*)b;
-                    break;
-                }
-                case ValueType::Double:
-                {
-                    auto dVal = std::dynamic_pointer_cast<DoubleValue>(val);
-                    double* b = new double(*dVal->GetValue());
-                    data[it->GetPosition() - 1] = (void*)b;
-                    break;
-                }
-                case ValueType::Integer:
-                {
-                    auto dVal = std::dynamic_pointer_cast<IntegerValue>(val);
-                    int* b = new int(*dVal->GetValue());
-                    data[it->GetPosition() - 1] = (void*)b;
-                    break;
-                }
-                // TODO: Implement list
-                default:
-                    errManager.RaiseError("Value type '" + HumanValueType(val->GetType())+ "' is not supported in extern functions.", "RuntimeError");
+                data[it->GetPosition() - 1] = (void*)str;
             }
+            else if (valType->Compare(ValType("bool")))
+            {
+                auto bVal = std::dynamic_pointer_cast<BoolValue>(val);
+                int* b = new int(bVal->GetValue() ? 1 : 0);
+                data[it->GetPosition() - 1] = (void*)b;
+            }
+            else if (valType->Compare(ValType("float")))
+            {
+                auto fVal = std::dynamic_pointer_cast<FloatValue>(val);
+                float* b = new float(*fVal->GetValue());
+                data[it->GetPosition() - 1] = (void*)b;
+            }
+            else if (valType->Compare(ValType("double")))
+            {
+                auto dVal = std::dynamic_pointer_cast<DoubleValue>(val);
+                double* b = new double(*dVal->GetValue());
+                data[it->GetPosition() - 1] = (void*)b;
+            }
+            else if (valType->Compare(ValType("int")))
+            {
+                auto dVal = std::dynamic_pointer_cast<IntegerValue>(val);
+                int* b = new int(*dVal->GetValue());
+                data[it->GetPosition() - 1] = (void*)b;
+            }
+            else
+                // TODO: use format of valtype
+                errManager.RaiseError("Value type '" + valType->GetName() + "' is not supported in extern functions.", "RuntimeError");
         }
 
         using LibFn = void*(*)(void**data, unsigned int argc);
@@ -149,47 +143,43 @@ namespace Runtime
         free(data);
 
         if (ret) {
-            switch(fn->GetReturnType())
+            auto retType = fn->GetReturnType();
+            if (retType->Compare(ValType("string")))
             {
-                case ValueType::String:
-                {
-                    char* str = (char*)ret;
-                    auto val = std::make_shared<StringValue>(std::string(str));
-                    free(str);
-                    return val;
-                }
-                case ValueType::Integer:
-                {
-                    int* v = (int*)ret;
-                    auto val = std::make_shared<IntegerValue>(*v);
-                    free(v);
-                    return val;
-                }
-                case ValueType::Float:
-                {
-                    float* v = (float*)ret;
-                    auto val = std::make_shared<FloatValue>(*v);
-                    free(v);
-                    return val;
-                }
-                case ValueType::Double:
-                {
-                    double* v = (double*)ret;
-                    auto val = std::make_shared<DoubleValue>(*v);
-                    free(v);
-                    return val;
-                }
-                case ValueType::Bool:
-                {
-                    int* v = (int*)ret;
-                    auto val = std::make_shared<BoolValue>(*v == 1);
-                    free(v);
-                    return val;
-                }
-                // TODO: Implement list
-                default:
-                    break;
+                char* str = (char*)ret;
+                auto val = std::make_shared<StringValue>(std::string(str));
+                free(str);
+                return val;
             }
+            if (retType->Compare(ValType("int")))
+            {
+                int* v = (int*)ret;
+                auto val = std::make_shared<IntegerValue>(*v);
+                free(v);
+                return val;
+            }
+            if (retType->Compare(ValType("float")))
+            {
+                float* v = (float*)ret;
+                auto val = std::make_shared<FloatValue>(*v);
+                free(v);
+                return val;
+            }
+            if (retType->Compare(ValType("double")))
+            {
+                double* v = (double*)ret;
+                auto val = std::make_shared<DoubleValue>(*v);
+                free(v);
+                return val;
+            }
+            if (retType->Compare(ValType("bool")))
+            {
+                int* v = (int*)ret;
+                auto val = std::make_shared<BoolValue>(*v == 1);
+                free(v);
+                return val;
+            }
+            // TODO: Implement list
         }
 
         return std::make_shared<NullValue>();

--- a/tmpl-script/src/interpreter/fn_extern_call.cpp
+++ b/tmpl-script/src/interpreter/fn_extern_call.cpp
@@ -1,5 +1,6 @@
 
 #include "include/iterator.h"
+#include "include/typechecker.h"
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -69,7 +70,8 @@ namespace Runtime
             it->Next();
             std::shared_ptr<Value> val = Execute(arg);
             auto valType = val->GetType();
-            if (valType->Compare(ValType("string")))
+            auto rootType = TypeChecker::GetRootType(GetFilename(), valType, arg->GetLocation(), m_type_definitions, "RuntimeError");
+            if (rootType->Compare(ValType("#BUILTIN_STRING")))
             {
                 auto sVal = std::dynamic_pointer_cast<StringValue>(val);
 #ifdef _WIN32
@@ -79,25 +81,25 @@ namespace Runtime
 #endif
                 data[it->GetPosition() - 1] = (void*)str;
             }
-            else if (valType->Compare(ValType("bool")))
+            else if (rootType->Compare(ValType("#BUILTIN_BOOL")))
             {
                 auto bVal = std::dynamic_pointer_cast<BoolValue>(val);
                 int* b = new int(bVal->GetValue() ? 1 : 0);
                 data[it->GetPosition() - 1] = (void*)b;
             }
-            else if (valType->Compare(ValType("float")))
+            else if (rootType->Compare(ValType("#BUILTIN_FLOAT")))
             {
                 auto fVal = std::dynamic_pointer_cast<FloatValue>(val);
                 float* b = new float(*fVal->GetValue());
                 data[it->GetPosition() - 1] = (void*)b;
             }
-            else if (valType->Compare(ValType("double")))
+            else if (rootType->Compare(ValType("#BUILTIN_DOUBLE")))
             {
                 auto dVal = std::dynamic_pointer_cast<DoubleValue>(val);
                 double* b = new double(*dVal->GetValue());
                 data[it->GetPosition() - 1] = (void*)b;
             }
-            else if (valType->Compare(ValType("int")))
+            else if (rootType->Compare(ValType("#BUILTIN_INT")))
             {
                 auto dVal = std::dynamic_pointer_cast<IntegerValue>(val);
                 int* b = new int(*dVal->GetValue());
@@ -144,35 +146,36 @@ namespace Runtime
 
         if (ret) {
             auto retType = fn->GetReturnType();
-            if (retType->Compare(ValType("string")))
+            auto rootType = TypeChecker::GetRootType(GetFilename(), retType, fn->GetLocation(), m_type_definitions, "RuntimeError");
+            if (rootType->Compare(ValType("#BUILTIN_STRING")))
             {
                 char* str = (char*)ret;
                 auto val = std::make_shared<StringValue>(std::string(str));
                 free(str);
                 return val;
             }
-            if (retType->Compare(ValType("int")))
+            if (rootType->Compare(ValType("#BUILTIN_INT")))
             {
                 int* v = (int*)ret;
                 auto val = std::make_shared<IntegerValue>(*v);
                 free(v);
                 return val;
             }
-            if (retType->Compare(ValType("float")))
+            if (rootType->Compare(ValType("#BUILTIN_FLOAT")))
             {
                 float* v = (float*)ret;
                 auto val = std::make_shared<FloatValue>(*v);
                 free(v);
                 return val;
             }
-            if (retType->Compare(ValType("double")))
+            if (rootType->Compare(ValType("#BUILTIN_DOUBLE")))
             {
                 double* v = (double*)ret;
                 auto val = std::make_shared<DoubleValue>(*v);
                 free(v);
                 return val;
             }
-            if (retType->Compare(ValType("bool")))
+            if (rootType->Compare(ValType("#BUILTIN_BOOL")))
             {
                 int* v = (int*)ret;
                 auto val = std::make_shared<BoolValue>(*v == 1);

--- a/tmpl-script/src/interpreter/fn_extern_call.cpp
+++ b/tmpl-script/src/interpreter/fn_extern_call.cpp
@@ -182,7 +182,7 @@ namespace Runtime
             // TODO: Implement list
         }
 
-        return std::make_shared<NullValue>();
+        return std::make_shared<VoidValue>();
     }
 }
 

--- a/tmpl-script/src/interpreter/if_else.cpp
+++ b/tmpl-script/src/interpreter/if_else.cpp
@@ -11,7 +11,7 @@ namespace Runtime
         auto condition = Execute(ifElse->GetCondition());
         auto condType = condition->GetType();
 
-        assert(condType == ValueType::Bool && "Condition returned non-boolean value. Should be handled by evaluate condition method");
+        assert(condType->Compare(ValType("bool")) && "Condition returned non-boolean value. Should be handled by evaluate condition method");
 
         auto condVal = std::dynamic_pointer_cast<BoolValue>(condition);
 

--- a/tmpl-script/src/interpreter/import.cpp
+++ b/tmpl-script/src/interpreter/import.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <cassert>
 #include "../../include/interpreter.h"
+#include "include/node/type.h"
 
 namespace fs = std::filesystem;
 
@@ -21,6 +22,9 @@ namespace Runtime
                 break;
             case NodeType::VarDecl:
                 EvaluateVariableDeclaration(std::dynamic_pointer_cast<VarDeclaration>(target));
+                break;
+            case NodeType::TypeDf:
+                EvaluateTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(target), true);
                 break;
             default:
                 assert(false && "Unreachable. Should be handled by parser.");

--- a/tmpl-script/src/interpreter/instance.cpp
+++ b/tmpl-script/src/interpreter/instance.cpp
@@ -1,0 +1,108 @@
+
+#include "include/interpreter.h"
+#include "include/iterator.h"
+#include "include/typechecker.h"
+
+namespace Runtime
+{
+    std::shared_ptr<Value> Interpreter::EvaluateInstance(std::shared_ptr<InstanceNode> instance)
+    {
+        PValType targetType = TypeChecker::EvaluateType(GetFilename(), instance->GetTarget());
+
+        if (!m_type_definitions->HasItem(targetType->GetName()))
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.TypeDoesNotExist(GetFilename(), targetType, instance->GetTarget()->GetLocation(), "RuntimeError");
+            return nullptr;
+        }
+
+        auto typeDf = m_type_definitions->LookUp(targetType->GetName());
+        assert(typeDf != nullptr && "Type definition should not be not found at this point.");
+
+        if (!typeDf->HasConstructor())
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.TypeConstructorDoesNotExist(GetFilename(), targetType, instance->GetTarget()->GetLocation(), "RuntimeError");
+            return nullptr;
+        }
+
+        auto fn = typeDf->GetConstructor();
+        assert(fn != nullptr && "Constructor fn should not be nullptr here.");
+
+        std::shared_ptr<Environment<Variable>> currentScope = m_variables;
+        std::shared_ptr<Environment<Variable>> variables = std::make_shared<Environment<Variable>>(m_variables);
+
+        auto fnCall = instance->GetFunctionCall();
+        auto fnName = targetType->GetName() + "::constructor";
+
+        if (GetFilename() != fn->GetModuleName() && !fn->IsExported())
+        {
+            Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+            errorManager.PrivateFunctionError(GetFilename(), fnName, fn->GetModuleName(), fnCall->GetLocation(), fn->GetLocation(), "RuntimeError");
+            return nullptr;
+        }
+
+        auto args = fnCall->GetArgs();
+
+        if (fn->GetParamsSize() != args->size())
+        {
+            Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+            errorManager.ArgsParamsExhausted(
+                    GetFilename(),
+                    fnName,
+                    args->size(),
+                    fn->GetParamsSize(),
+                    fnCall->GetLocation(), "RuntimeError");
+            return nullptr;
+        }
+
+        auto it = std::make_shared<Common::Iterator>(fn->GetParamsSize());
+        while (it->HasItems())
+        {
+            auto param = fn->GetItem(it->GetPosition());
+            std::shared_ptr<Node> arg = (*args)[it->GetPosition()];
+            it->Next();
+            std::shared_ptr<Value> val = Execute(arg);
+            if (!val->GetType()->Compare(*param->GetType()))
+            {
+                Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+                errorManager.ArgMismatchType(
+                        GetFilename(),
+                        param->GetName(),
+                        val->GetType(),
+                        param->GetType(),
+                        arg->GetLocation(),
+                        "RuntimeError"
+                        );
+                return nullptr;
+            }
+            if (!fn->IsExterned())
+            {
+                std::shared_ptr<Variable> var =
+                    std::make_shared<Variable>(val->GetType(), val, false);
+                variables->AddItem(param->GetName(), var);
+            }
+        }
+
+        auto currentModule = GetFilename();
+        SetFilename(fn->GetModuleName());
+        m_variables = variables;
+
+        std::shared_ptr<Value> value = Execute(fn->GetBody());
+
+        m_variables = currentScope;
+        SetFilename(currentModule);
+
+        if (!value->GetType()->Compare(*fn->GetReturnType()))
+        {
+            Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+            errorManager.ReturnMismatchType(GetFilename(), fnName, value->GetType(), fn->GetReturnType(), fnCall->GetLocation());
+            return nullptr;
+        }
+
+        value->SetType(targetType);
+
+        return value;
+    }
+}
+

--- a/tmpl-script/src/interpreter/instance.cpp
+++ b/tmpl-script/src/interpreter/instance.cpp
@@ -19,6 +19,13 @@ namespace Runtime
         auto typeDf = m_type_definitions->LookUp(targetType->GetName());
         assert(typeDf != nullptr && "Type definition should not be not found at this point.");
 
+        if (GetFilename() != typeDf->GetModuleName() && !typeDf->IsExported())
+        {
+            Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+            errorManager.PrivateTypeError(GetFilename(), typeDf->GetTypeName(), typeDf->GetModuleName(), instance->GetLocation(), typeDf->GetLocation(), "RuntimeError");
+            return std::make_shared<VoidValue>();
+        }
+
         if (!typeDf->HasConstructor())
         {
             Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();

--- a/tmpl-script/src/interpreter/type.cpp
+++ b/tmpl-script/src/interpreter/type.cpp
@@ -1,0 +1,85 @@
+
+#include "include/interpreter.h"
+
+namespace Runtime
+{
+    std::shared_ptr<Value> Interpreter::CastValue(std::shared_ptr<Value> val, PValType to, Location loc)
+    {
+        auto typeDfs = m_type_definitions;
+        auto from = val->GetType();
+        // 0. check if "from" type exists in typeDfs
+        if (!typeDfs->HasItem(from->GetName()))
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.TypeDoesNotExist(GetFilename(), from, loc, "RuntimeError");
+            return std::make_shared<VoidValue>();
+        }
+        // 1. check if "to" type exists in typeDfs
+        if (!typeDfs->HasItem(to->GetName()))
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.TypeDoesNotExist(GetFilename(), to, loc, "RuntimeError");
+            return std::make_shared<VoidValue>();
+        }
+        // 2. check if "from" and "to" types are equal
+        if (from->Compare(*to))
+        {
+            val->SetType(to);
+            return val;
+        }
+        // 3. check if "from" type's name is "to" type's basename
+        auto fromDf = typeDfs->LookUp(from->GetName());
+        assert(fromDf != nullptr && "From type's definition should not be null");
+        if (fromDf->GetBaseType()->Compare(*to)) 
+        {
+            val->SetType(to);
+            return val;
+        }
+        // 4. otherwise check if "from" type contains cast to "to" type in typeDf
+        auto casts = fromDf->GetCastsEnv();
+        if (casts->HasItem(to->GetName()))
+        {
+            auto cast = casts->LookUp(to->GetName());
+            assert(cast != nullptr && "Found cast should not be null");
+
+            auto fnName = "cast(" + cast->GetOrigin() + " -> " + cast->GetTarget() + ")";
+            auto fn = cast->GetCaster();
+
+            std::shared_ptr<Environment<Variable>> currentScope = m_variables;
+            std::shared_ptr<Environment<Variable>> variables = std::make_shared<Environment<Variable>>(m_variables);
+
+            auto selfVar = std::make_shared<Variable>(from, val, false);
+            variables->AddItem("self", selfVar);
+
+            if (GetFilename() != fn->GetModuleName() && !fn->IsExported())
+            {
+                Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+                errorManager.PrivateFunctionError(GetFilename(), fnName, fn->GetModuleName(), loc, fn->GetLocation(), "RuntimeError");
+                return nullptr;
+            }
+
+            auto currentModule = GetFilename();
+            SetFilename(fn->GetModuleName());
+            m_variables = variables;
+
+            std::shared_ptr<Value> value = Execute(fn->GetBody());
+
+            m_variables = currentScope;
+            SetFilename(currentModule);
+
+            if (!value->GetType()->Compare(*fn->GetReturnType()))
+            {
+                Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+                errorManager.ReturnMismatchType(GetFilename(), fnName, value->GetType(), fn->GetReturnType(), loc);
+                return nullptr;
+            }
+
+            return value;
+        }
+
+        Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+        errManager.TypeCastNotPossible(GetFilename(), from, to, loc, "RuntimeError");
+        return std::make_shared<VoidValue>();
+    }
+}
+

--- a/tmpl-script/src/interpreter/typedf.cpp
+++ b/tmpl-script/src/interpreter/typedf.cpp
@@ -1,0 +1,26 @@
+
+#include "include/interpreter.h"
+
+namespace Runtime
+{
+    void Interpreter::EvaluateTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn)
+    {
+        // check if type already exists
+        auto typeName = typeDfn->GetTypeTemplate();
+
+        if (m_type_definitions->HasItem(typeName->GetTypeName()->GetName()))
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.TypeRedeclaration(GetFilename(), typeName, "RuntimeError");
+            return;
+        }
+
+        auto baseType = typeDfn->GetTypeValue();
+
+        std::string key = typeName->GetTypeName()->GetName();
+        auto typeDf = std::make_shared<TypeDf>(key, baseType->GetTypeName()->GetName());
+
+        m_type_definitions->AddItem(key, typeDf);
+    }
+}
+

--- a/tmpl-script/src/interpreter/typedf.cpp
+++ b/tmpl-script/src/interpreter/typedf.cpp
@@ -1,5 +1,6 @@
 
 #include "include/interpreter.h"
+#include "include/typechecker.h"
 
 namespace Runtime
 {
@@ -18,7 +19,7 @@ namespace Runtime
         auto baseType = typeDfn->GetTypeValue();
 
         std::string key = typeName->GetTypeName()->GetName();
-        auto typeDf = std::make_shared<TypeDf>(key, baseType->GetTypeName()->GetName());
+        auto typeDf = std::make_shared<TypeDf>(key, TypeChecker::EvaluateType(GetFilename(), baseType));
 
         m_type_definitions->AddItem(key, typeDf);
     }

--- a/tmpl-script/src/interpreter/typedf.cpp
+++ b/tmpl-script/src/interpreter/typedf.cpp
@@ -4,7 +4,7 @@
 
 namespace Runtime
 {
-    void Interpreter::EvaluateTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn)
+    void Interpreter::EvaluateTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn, bool exported)
     {
         // check if type already exists
         auto typeName = typeDfn->GetTypeTemplate();
@@ -19,7 +19,7 @@ namespace Runtime
         auto baseType = typeDfn->GetTypeValue();
 
         std::string key = typeName->GetTypeName()->GetName();
-        auto typeDf = std::make_shared<TypeDf>(key, TypeChecker::EvaluateType(GetFilename(), baseType));
+        auto typeDf = std::make_shared<TypeDf>(key, TypeChecker::EvaluateType(GetFilename(), baseType), GetFilename(), exported, typeDfn->GetLocation());
 
         m_type_definitions->AddItem(key, typeDf);
     }

--- a/tmpl-script/src/interpreter/value.cpp
+++ b/tmpl-script/src/interpreter/value.cpp
@@ -149,14 +149,14 @@ namespace Runtime
 		return nullptr;
 	}
 
-    // NullValue
+    // VoidValue
 
-	std::string NullValue::format() const
+	std::string VoidValue::format() const
 	{
-		return "NullValue()";
+		return "VoidValue()";
 	}
 
-	std::shared_ptr<Value> Runtime::NullValue::Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition)
+	std::shared_ptr<Value> Runtime::VoidValue::Compare(std::shared_ptr<Value> right, AST::Nodes::Condition::ConditionType condition)
 	{
 		std::shared_ptr<Value> iright = std::dynamic_pointer_cast<Value>(right);
 
@@ -180,7 +180,7 @@ namespace Runtime
 		return nullptr;
 	}
 
-	std::shared_ptr<Value> Runtime::NullValue::Operate(std::shared_ptr<Value> right, AST::Nodes::ExpressionNode::OperatorType opType)
+	std::shared_ptr<Value> Runtime::VoidValue::Operate(std::shared_ptr<Value> right, AST::Nodes::ExpressionNode::OperatorType opType)
 	{
 		std::shared_ptr<IntegerValue> iright = std::dynamic_pointer_cast<IntegerValue>(right);
 

--- a/tmpl-script/src/interpreter/value.cpp
+++ b/tmpl-script/src/interpreter/value.cpp
@@ -72,7 +72,7 @@ namespace Runtime
 
     std::shared_ptr<Value> Runtime::ListValue::GetItem(std::shared_ptr<Value> indexVal)
     {
-        if (indexVal->GetType() != ValueType::Integer)
+        if (!indexVal->GetType()->Compare(ValType("int")))
         {
 			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
 			errorManager.RaiseError("Non-integers values cannot be used as index for a list", "RuntimeError");
@@ -163,9 +163,9 @@ namespace Runtime
 		switch (condition)
 		{
 		case AST::Nodes::Condition::ConditionType::Compare:
-			return std::make_shared<BoolValue>(iright->GetType() == ValueType::Null);
+			return std::make_shared<BoolValue>(iright->GetType()->Compare(ValType("void")));
 		case AST::Nodes::Condition::ConditionType::NotEqual:
-			return std::make_shared<BoolValue>(iright->GetType() != ValueType::Null);
+			return std::make_shared<BoolValue>(!iright->GetType()->Compare(ValType("void")));
 		default:
 			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
 			errorManager.RaiseError("Unsupported operator for undefined: " + std::to_string((int)condition), "RuntimeError");

--- a/tmpl-script/src/interpreter/value.cpp
+++ b/tmpl-script/src/interpreter/value.cpp
@@ -6,6 +6,13 @@
 namespace Runtime
 {
 	// Common
+    
+    std::ostream &operator<<(std::ostream& stream, const CustomValueType &x)
+    {
+        stream << x.m_name;
+
+        return stream;
+    }
 
 	std::ostream &operator<<(std::ostream &stream, const Value &value)
 	{

--- a/tmpl-script/src/interpreter/value.cpp
+++ b/tmpl-script/src/interpreter/value.cpp
@@ -70,17 +70,9 @@ namespace Runtime
         m_value.push_back(item);
     }
 
-    std::shared_ptr<Value> Runtime::ListValue::GetItem(std::shared_ptr<Value> indexVal)
+    std::shared_ptr<Value> Runtime::ListValue::GetItem(std::shared_ptr<IntegerValue> indexVal)
     {
-        if (!indexVal->GetType()->Compare(ValType("int")))
-        {
-			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-			errorManager.RaiseError("Non-integers values cannot be used as index for a list", "RuntimeError");
-			return nullptr;
-        }
-
-        std::shared_ptr<IntegerValue> vl = std::dynamic_pointer_cast<IntegerValue>(indexVal);
-        std::shared_ptr<int> index = vl->GetValue();
+        std::shared_ptr<int> index = indexVal->GetValue();
 
         if (*index < 0)
         {

--- a/tmpl-script/src/interpreter/value.cpp
+++ b/tmpl-script/src/interpreter/value.cpp
@@ -60,9 +60,9 @@ namespace Runtime
     std::shared_ptr<Value> Runtime::ListValue::Operate(std::shared_ptr<Value> right,
             AST::Nodes::ExpressionNode::OperatorType opType)
     {
-			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-			errorManager.RaiseError("Lists are not operateable", "RuntimeError");
-			return nullptr;
+        Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+        errorManager.RaiseError("Lists are not operateable", "RuntimeError");
+        return nullptr;
     }
 
     void Runtime::ListValue::AddItem(std::shared_ptr<Value> item)
@@ -129,10 +129,6 @@ namespace Runtime
 
 	std::shared_ptr<Value> Runtime::BoolValue::Operate(std::shared_ptr<Value> right, AST::Nodes::ExpressionNode::OperatorType opType)
 	{
-		std::shared_ptr<BoolValue> iright = std::dynamic_pointer_cast<BoolValue>(right);
-		bool vleft = GetValue();
-		bool vright = iright->GetValue();
-
         Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
         errorManager.RaiseError("Bool values do not support any operations", "RuntimeError");
 
@@ -174,8 +170,6 @@ namespace Runtime
 
 	std::shared_ptr<Value> Runtime::VoidValue::Operate(std::shared_ptr<Value> right, AST::Nodes::ExpressionNode::OperatorType opType)
 	{
-		std::shared_ptr<IntegerValue> iright = std::dynamic_pointer_cast<IntegerValue>(right);
-
         Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
         errorManager.RaiseError("Null values does not support any operations", "RuntimeError");
         return nullptr;
@@ -225,16 +219,32 @@ namespace Runtime
 		int vright = *iright->GetValue();
 
 		switch (opType)
-		{
-		case AST::Nodes::ExpressionNode::OperatorType::DIVIDE:
-			return std::make_shared<IntegerValue>(vleft / vright);
-		case AST::Nodes::ExpressionNode::OperatorType::MULTIPLY:
-			return std::make_shared<IntegerValue>(vleft * vright);
-		case AST::Nodes::ExpressionNode::OperatorType::PLUS:
-			return std::make_shared<IntegerValue>(vleft + vright);
-		case AST::Nodes::ExpressionNode::OperatorType::MINUS:
-			return std::make_shared<IntegerValue>(vleft - vright);
-		}
+        {
+            case AST::Nodes::ExpressionNode::OperatorType::DIVIDE:
+                {
+                    auto nv = std::dynamic_pointer_cast<IntegerValue>(iright->Clone());
+                    nv->SetValue(vleft / vright);
+                    return nv;
+                }
+            case AST::Nodes::ExpressionNode::OperatorType::MULTIPLY:
+                {
+                    auto nv = std::dynamic_pointer_cast<IntegerValue>(iright->Clone());
+                    nv->SetValue(vleft * vright);
+                    return nv;
+                }
+            case AST::Nodes::ExpressionNode::OperatorType::PLUS:
+                {
+                    auto nv = std::dynamic_pointer_cast<IntegerValue>(iright->Clone());
+                    nv->SetValue(vleft + vright);
+                    return nv;
+                }
+            case AST::Nodes::ExpressionNode::OperatorType::MINUS:
+                {
+                    auto nv = std::dynamic_pointer_cast<IntegerValue>(iright->Clone());
+                    nv->SetValue(vleft - vright);
+                    return nv;
+                }
+        }
 
         assert(opType != AST::Nodes::ExpressionNode::OperatorType::NONE &&
                 "Exhausted operate operation handlers for integer");
@@ -288,16 +298,32 @@ namespace Runtime
 		float vright = *iright->GetValue();
 
 		switch (opType)
-		{
-		case AST::Nodes::ExpressionNode::OperatorType::DIVIDE:
-			return std::make_shared<FloatValue>(vleft / vright);
-		case AST::Nodes::ExpressionNode::OperatorType::MULTIPLY:
-			return std::make_shared<FloatValue>(vleft * vright);
-		case AST::Nodes::ExpressionNode::OperatorType::PLUS:
-			return std::make_shared<FloatValue>(vleft + vright);
-		case AST::Nodes::ExpressionNode::OperatorType::MINUS:
-			return std::make_shared<FloatValue>(vleft - vright);
-		}
+        {
+            case AST::Nodes::ExpressionNode::OperatorType::DIVIDE:
+                {
+                    auto nv = std::dynamic_pointer_cast<FloatValue>(iright->Clone());
+                    nv->SetValue(vleft / vright);
+                    return nv;
+                }
+            case AST::Nodes::ExpressionNode::OperatorType::MULTIPLY:
+                {
+                    auto nv = std::dynamic_pointer_cast<FloatValue>(iright->Clone());
+                    nv->SetValue(vleft * vright);
+                    return nv;
+                }
+            case AST::Nodes::ExpressionNode::OperatorType::PLUS:
+                {
+                    auto nv = std::dynamic_pointer_cast<FloatValue>(iright->Clone());
+                    nv->SetValue(vleft + vright);
+                    return nv;
+                }
+            case AST::Nodes::ExpressionNode::OperatorType::MINUS:
+                {
+                    auto nv = std::dynamic_pointer_cast<FloatValue>(iright->Clone());
+                    nv->SetValue(vleft - vright);
+                    return nv;
+                }
+        }
 
         assert(opType != AST::Nodes::ExpressionNode::OperatorType::NONE &&
                 "Exhausted operate operation handlers for float");
@@ -353,13 +379,29 @@ namespace Runtime
 		switch (opType)
 		{
 		case AST::Nodes::ExpressionNode::OperatorType::DIVIDE:
-			return std::make_shared<DoubleValue>(vleft / vright);
+        {
+            auto nv = std::dynamic_pointer_cast<DoubleValue>(iright->Clone());
+            nv->SetValue(vleft / vright);
+            return nv;
+        }
 		case AST::Nodes::ExpressionNode::OperatorType::MULTIPLY:
-			return std::make_shared<DoubleValue>(vleft * vright);
+        {
+            auto nv = std::dynamic_pointer_cast<DoubleValue>(iright->Clone());
+            nv->SetValue(vleft * vright);
+            return nv;
+        }
 		case AST::Nodes::ExpressionNode::OperatorType::PLUS:
-			return std::make_shared<DoubleValue>(vleft + vright);
+        {
+            auto nv = std::dynamic_pointer_cast<DoubleValue>(iright->Clone());
+            nv->SetValue(vleft + vright);
+            return nv;
+        }
 		case AST::Nodes::ExpressionNode::OperatorType::MINUS:
-			return std::make_shared<DoubleValue>(vleft - vright);
+        {
+            auto nv = std::dynamic_pointer_cast<DoubleValue>(iright->Clone());
+            nv->SetValue(vleft - vright);
+            return nv;
+        }
 		}
 
         assert(opType != AST::Nodes::ExpressionNode::OperatorType::NONE &&
@@ -409,7 +451,11 @@ namespace Runtime
 		switch (opType)
 		{
 		case AST::Nodes::ExpressionNode::OperatorType::PLUS:
-			return std::make_shared<StringValue>(vleft + vright);
+        {
+            auto nv = std::dynamic_pointer_cast<StringValue>(iright->Clone());
+            nv->SetValue(vleft + vright);
+            return nv;
+        }
 		default:
 			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
 			errorManager.RaiseError("Unsupported operator for string literals: " + std::to_string((int)opType), "RuntimeError");

--- a/tmpl-script/src/interpreter/var_decl.cpp
+++ b/tmpl-script/src/interpreter/var_decl.cpp
@@ -8,11 +8,11 @@ namespace Runtime
 
 	void Interpreter::EvaluateVariableDeclaration(std::shared_ptr<VarDeclaration> varDecl)
 	{
-		ValueType varType = TypeChecker::EvaluateType(GetFilename(), varDecl->GetType());
+		PValType varType = TypeChecker::EvaluateType(GetFilename(), varDecl->GetType());
 		std::string varName = *varDecl->GetName();
 		std::shared_ptr<Value> varValue = Execute(varDecl->GetValue());
 
-		if (varType != varValue->GetType())
+		if (!varType->Compare(*varValue->GetType()))
 		{
 			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
 			errorManager.VarMismatchType(GetFilename(), varName, varValue->GetType(), varType, varDecl->GetLocation(), "RuntimeError");

--- a/tmpl-script/src/lexer.cpp
+++ b/tmpl-script/src/lexer.cpp
@@ -270,6 +270,8 @@ namespace AST
             m_tokens.push_back(std::make_shared<Token>(TokenType::True, m_line, m_col));
 		else if (*id == "false")
             m_tokens.push_back(std::make_shared<Token>(TokenType::False, m_line, m_col));
+		else if (*id == "typedf")
+            m_tokens.push_back(std::make_shared<Token>(TokenType::TypeDf, m_line, m_col));
 		else
 		{
 			std::shared_ptr<Token::TypedValueHolder<std::string>> value = std::make_shared<Token::TypedValueHolder<std::string>>(std::make_shared<std::string>(*id));

--- a/tmpl-script/src/lexer.cpp
+++ b/tmpl-script/src/lexer.cpp
@@ -276,6 +276,8 @@ namespace AST
             m_tokens.push_back(std::make_shared<Token>(TokenType::Construct, m_line, m_col));
 		else if (*id == "new")
             m_tokens.push_back(std::make_shared<Token>(TokenType::New, m_line, m_col));
+		else if (*id == "cast")
+            m_tokens.push_back(std::make_shared<Token>(TokenType::Cast, m_line, m_col));
 		else
 		{
 			std::shared_ptr<Token::TypedValueHolder<std::string>> value = std::make_shared<Token::TypedValueHolder<std::string>>(std::make_shared<std::string>(*id));

--- a/tmpl-script/src/lexer.cpp
+++ b/tmpl-script/src/lexer.cpp
@@ -401,6 +401,15 @@ namespace AST
 		return m_tokens[m_index];
 	}
 
+    void Lexer::RestoreState()
+    {
+        assert(m_state != nullptr && "State is required for restoring.");
+
+        m_index = m_state->index;
+
+        m_state = nullptr;
+    }
+
 	std::shared_ptr<Token> Lexer::SeekToken()
 	{
 		if (m_index + 1 >= m_tokens.size())

--- a/tmpl-script/src/lexer.cpp
+++ b/tmpl-script/src/lexer.cpp
@@ -274,6 +274,8 @@ namespace AST
             m_tokens.push_back(std::make_shared<Token>(TokenType::TypeDf, m_line, m_col));
 		else if (*id == "construct")
             m_tokens.push_back(std::make_shared<Token>(TokenType::Construct, m_line, m_col));
+		else if (*id == "new")
+            m_tokens.push_back(std::make_shared<Token>(TokenType::New, m_line, m_col));
 		else
 		{
 			std::shared_ptr<Token::TypedValueHolder<std::string>> value = std::make_shared<Token::TypedValueHolder<std::string>>(std::make_shared<std::string>(*id));

--- a/tmpl-script/src/lexer.cpp
+++ b/tmpl-script/src/lexer.cpp
@@ -272,6 +272,8 @@ namespace AST
             m_tokens.push_back(std::make_shared<Token>(TokenType::False, m_line, m_col));
 		else if (*id == "typedf")
             m_tokens.push_back(std::make_shared<Token>(TokenType::TypeDf, m_line, m_col));
+		else if (*id == "construct")
+            m_tokens.push_back(std::make_shared<Token>(TokenType::Construct, m_line, m_col));
 		else
 		{
 			std::shared_ptr<Token::TypedValueHolder<std::string>> value = std::make_shared<Token::TypedValueHolder<std::string>>(std::make_shared<std::string>(*id));

--- a/tmpl-script/src/main.cpp
+++ b/tmpl-script/src/main.cpp
@@ -10,7 +10,7 @@
 #include "../include/cli.h"
 #include "../include/error.h"
 #include "../include/typechecker.h"
-#include "include/typechecker/typedf.h"
+#include "../include/helper.h"
 
 int main(int argc, char **argv)
 {
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
 	auto functions = std::make_shared<Environment<Fn>>();
 	auto modules = std::make_shared<Environment<std::string>>();
     auto typeFunctions = std::make_shared<Environment<Environment<Fn>>>();
-    auto typeDefinitions = std::make_shared<Environment<TypeDf>>();
+    auto typeDefinitions = Helper::Helper::GetTypeDefinitions();
 
 	Interpreter intrpt(parser, variables, procedures, functions, modules, typeFunctions, typeDefinitions);
 

--- a/tmpl-script/src/main.cpp
+++ b/tmpl-script/src/main.cpp
@@ -10,6 +10,7 @@
 #include "../include/cli.h"
 #include "../include/error.h"
 #include "../include/typechecker.h"
+#include "include/typechecker/typedf.h"
 
 int main(int argc, char **argv)
 {
@@ -50,8 +51,9 @@ int main(int argc, char **argv)
 	auto functions = std::make_shared<Environment<Fn>>();
 	auto modules = std::make_shared<Environment<std::string>>();
     auto typeFunctions = std::make_shared<Environment<Environment<Fn>>>();
+    auto typeDefinitions = std::make_shared<Environment<TypeDf>>();
 
-	Interpreter intrpt(parser, variables, procedures, functions, modules, typeFunctions);
+	Interpreter intrpt(parser, variables, procedures, functions, modules, typeFunctions, typeDefinitions);
 
 	std::shared_ptr<ProgramNode> program = std::dynamic_pointer_cast<ProgramNode>(parser->GetRoot());
 

--- a/tmpl-script/src/main.cpp
+++ b/tmpl-script/src/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 	auto procedures = std::make_shared<Environment<Procedure>>();
 	auto functions = std::make_shared<Environment<Fn>>();
 	auto modules = std::make_shared<Environment<std::string>>();
-    auto typeFunctions = std::make_shared<Environment<Environment<Fn>, Runtime::ValueType>>();
+    auto typeFunctions = std::make_shared<Environment<Environment<Fn>>>();
 
 	Interpreter intrpt(parser, variables, procedures, functions, modules, typeFunctions);
 
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
     }
 
     std::shared_ptr<Variable> argsVar = std::make_shared<Variable>(
-        ValueType::List,
+        std::make_shared<ValType>("list"),
         argsList,
         false
     );

--- a/tmpl-script/src/node/cast.cpp
+++ b/tmpl-script/src/node/cast.cpp
@@ -1,0 +1,11 @@
+
+#include "include/node/cast.h"
+
+namespace AST::Nodes
+{
+    std::string CastNode::Format() const
+    {
+        return "CastNode(" + m_type->Format() + ", " + m_expr->Format() + ")";
+    }
+}
+

--- a/tmpl-script/src/node/instance.cpp
+++ b/tmpl-script/src/node/instance.cpp
@@ -1,0 +1,14 @@
+
+#include "include/node/instance.h"
+
+namespace AST
+{
+    namespace Nodes
+    {
+        std::string InstanceNode::Format() const
+        {
+            return "Instance(" + m_target->Format() + ", " + m_fcall->Format() + ")";
+        }
+    }
+}
+

--- a/tmpl-script/src/node/type.cpp
+++ b/tmpl-script/src/node/type.cpp
@@ -6,5 +6,15 @@ namespace AST::Nodes
     {
         return "TypeNode(" + m_typename->Format() + ")";
     }
+
+    std::string TypeTemplateNode::Format() const
+    {
+        return "TypeTemplateNode(" + m_typename->Format() + ")";
+    }
+
+    std::string TypeDfNode::Format() const
+    {
+        return "TypeDf(" + m_template->Format() + " = " + m_value->Format() + ")";
+    }
 }
 

--- a/tmpl-script/src/node/type.cpp
+++ b/tmpl-script/src/node/type.cpp
@@ -1,0 +1,10 @@
+#include "include/node/type.h"
+
+namespace AST::Nodes
+{
+    std::string TypeNode::Format() const
+    {
+        return "TypeNode(" + m_typename->Format() + ")";
+    }
+}
+

--- a/tmpl-script/src/parser.cpp
+++ b/tmpl-script/src/parser.cpp
@@ -79,6 +79,7 @@ namespace AST
             break;
         case TokenType::TypeDf:
             stmt = TypeDfStatement();
+            Eat(TokenType::Semicolon);
             break;
         case TokenType::At:
         {

--- a/tmpl-script/src/parser.cpp
+++ b/tmpl-script/src/parser.cpp
@@ -77,6 +77,9 @@ namespace AST
         case TokenType::Export:
             stmt = ExportStmt();
             break;
+        case TokenType::TypeDf:
+            stmt = TypeDfStatement();
+            break;
         case TokenType::At:
         {
             auto tokenType = Peek();

--- a/tmpl-script/src/parser/expr.cpp
+++ b/tmpl-script/src/parser/expr.cpp
@@ -280,6 +280,23 @@ namespace AST
 
             std::shared_ptr<Node> res = Ternary();
             Eat(TokenType::CloseBracket);
+
+			TokenType current_type = m_lexer->GetToken()->GetType();
+			while (current_type == TokenType::OpenBracket || current_type == TokenType::Point || current_type == TokenType::OpenSquareBracket)
+			{
+				if (current_type == TokenType::OpenBracket)
+				{
+					std::shared_ptr<Node> fcall = FunctionCall(res);
+					res = fcall;
+				}
+				else if (current_type == TokenType::Point || current_type == TokenType::OpenSquareBracket)
+				{
+					std::shared_ptr<Node> objm = ObjectMember(res);
+					res = objm;
+				}
+				current_type = m_lexer->GetToken()->GetType();
+			}
+
             return res;
 		}
 		else if (token->GetType() == TokenType::New)

--- a/tmpl-script/src/parser/expr.cpp
+++ b/tmpl-script/src/parser/expr.cpp
@@ -4,6 +4,7 @@
 #include "../../include/node/literal.h"
 #include "../../include/node/logical.h"
 #include "../../include/node/unary.h"
+#include "include/node/instance.h"
 #include "include/token.h"
 
 namespace AST
@@ -273,6 +274,14 @@ namespace AST
 			Eat(TokenType::CloseBracket);
 			return res;
 		}
+		else if (token->GetType() == TokenType::New)
+        {
+            auto loc = m_lexer->GetToken()->GetLocation();
+            Eat(TokenType::New);
+            auto fnName = Type();
+            auto fCall = FunctionCall(fnName);
+            return std::make_shared<Nodes::InstanceNode>(fnName, fCall, loc);
+        }
 		// unknown
 		else
 		{

--- a/tmpl-script/src/parser/expr.cpp
+++ b/tmpl-script/src/parser/expr.cpp
@@ -270,9 +270,17 @@ namespace AST
 		else if (token->GetType() == TokenType::OpenBracket)
 		{
 			Eat(TokenType::OpenBracket);
-			std::shared_ptr<Node> res = Ternary();
-			Eat(TokenType::CloseBracket);
-			return res;
+
+            if (IsTypeCastAhead())
+            {
+                auto typ = Type();
+
+                return Cast(typ);
+            }
+
+            std::shared_ptr<Node> res = Ternary();
+            Eat(TokenType::CloseBracket);
+            return res;
 		}
 		else if (token->GetType() == TokenType::New)
         {

--- a/tmpl-script/src/parser/statement.cpp
+++ b/tmpl-script/src/parser/statement.cpp
@@ -48,11 +48,19 @@ namespace AST
         auto fnLoc = m_lexer->GetToken()->GetLocation();
         Eat(TokenType::Fn);
 
-        std::shared_ptr<Node> fnName = Id();
-        if (m_lexer->GetToken()->GetType() == TokenType::Point)
+        std::shared_ptr<Node> fnName;
+
+        if (m_lexer->SeekToken()->GetType() == TokenType::Point)
         {
+            fnName = Type();
             fnName = ObjectMember(fnName);
         }
+        else
+        {
+            fnName = Id();
+        }
+
+        assert(fnName != nullptr && "Fn name shouldn't be left null in signature");
 
         Eat(TokenType::OpenBracket);
 

--- a/tmpl-script/src/parser/statement.cpp
+++ b/tmpl-script/src/parser/statement.cpp
@@ -61,6 +61,7 @@ namespace AST
                 case TokenType::Construct:
                     Eat(TokenType::Construct);
                     modifier = Nodes::FunctionModifier::Construct;
+                    break;
                 default:
                 {
                     Prelude::ErrorManager& errManager = GetErrorManager();
@@ -72,7 +73,7 @@ namespace AST
 
         std::shared_ptr<Node> fnName;
 
-        if (m_lexer->SeekToken()->GetType() == TokenType::Point)
+        if (m_lexer->SeekToken()->GetType() == TokenType::Point && modifier == Nodes::FunctionModifier::None)
         {
             fnName = Type();
             fnName = ObjectMember(fnName);

--- a/tmpl-script/src/parser/statement.cpp
+++ b/tmpl-script/src/parser/statement.cpp
@@ -32,6 +32,10 @@ namespace AST
                 target = VariableDeclaration();
                 Eat(TokenType::Semicolon);
                 break;
+            case TokenType::TypeDf:
+                target = TypeDfStatement();
+                Eat(TokenType::Semicolon);
+                break;
             default:
                 Prelude::ErrorManager &manager = GetErrorManager();
                 manager.UnexpectedToken(GetFilename(), token);

--- a/tmpl-script/src/parser/statement.cpp
+++ b/tmpl-script/src/parser/statement.cpp
@@ -72,7 +72,7 @@ namespace AST
                 Eat(TokenType::Comma);
             }
             // TODO: support for complex types
-            std::shared_ptr<Node> type = Id();
+            std::shared_ptr<Nodes::TypeNode> type = Type();
             std::shared_ptr<Nodes::IdentifierNode> name = Id();
             std::shared_ptr<Nodes::FunctionParam> param = std::make_shared<Nodes::FunctionParam>(type, name);
             fn->AddParam(param);
@@ -84,7 +84,7 @@ namespace AST
         Eat(TokenType::Colon);
 
         // TODO: support for complex types
-        std::shared_ptr<Node> retType = Id();
+        std::shared_ptr<Nodes::TypeNode> retType = Type();
 
         fn->SetReturnType(retType);
 
@@ -154,8 +154,7 @@ namespace AST
 		else
 			Eat(TokenType::Const);
 
-        // TODO: support for complex types
-		std::shared_ptr<Node> type = Id();
+		std::shared_ptr<Nodes::TypeNode> type = Type();
 
 		std::shared_ptr<Nodes::IdentifierNode> nameNode = Id();
 		std::shared_ptr<std::string> name = std::make_shared<std::string>(nameNode->GetName());

--- a/tmpl-script/src/parser/type.cpp
+++ b/tmpl-script/src/parser/type.cpp
@@ -30,12 +30,17 @@ namespace AST
     {
         m_lexer->SaveState();
 
+        if (m_lexer->GetToken()->GetType() != TokenType::Id)
+        {
+            return false;
+        }
+
         while (m_lexer->GetToken()->GetType() != TokenType::CloseBracket && m_lexer->GetToken()->GetType() != TokenType::_EOF)
         {
             Eat(m_lexer->GetToken()->GetType());
         }
 
-        Eat(TokenType::CloseBracket);
+        Eat(m_lexer->GetToken()->GetType());
 
         auto curr = m_lexer->GetToken()->GetType();
 

--- a/tmpl-script/src/parser/type.cpp
+++ b/tmpl-script/src/parser/type.cpp
@@ -1,0 +1,12 @@
+#include "include/parser.h"
+
+namespace AST
+{
+    std::shared_ptr<Nodes::TypeNode> Parser::Type()
+    {
+        auto target = Id();
+
+        return std::make_shared<Nodes::TypeNode>(target, target->GetLocation());
+    }
+}
+

--- a/tmpl-script/src/parser/type.cpp
+++ b/tmpl-script/src/parser/type.cpp
@@ -1,4 +1,5 @@
 #include "include/parser.h"
+#include "include/token.h"
 
 namespace AST
 {
@@ -14,6 +15,33 @@ namespace AST
         auto target = Id();
 
         return std::make_shared<Nodes::TypeTemplateNode>(target, target->GetLocation());
+    }
+
+    std::shared_ptr<Nodes::CastNode> Parser::Cast(std::shared_ptr<Nodes::TypeNode> typ)
+    {
+        Eat(TokenType::CloseBracket);
+
+        auto target = Factor();
+
+        return std::make_shared<Nodes::CastNode>(typ, target, typ->GetLocation());
+    }
+
+    bool Parser::IsTypeCastAhead()
+    {
+        m_lexer->SaveState();
+
+        while (m_lexer->GetToken()->GetType() != TokenType::CloseBracket && m_lexer->GetToken()->GetType() != TokenType::_EOF)
+        {
+            Eat(m_lexer->GetToken()->GetType());
+        }
+
+        Eat(TokenType::CloseBracket);
+
+        auto curr = m_lexer->GetToken()->GetType();
+
+        m_lexer->RestoreState();
+
+        return curr == TokenType::Id || curr == TokenType::OpenBracket;
     }
 
     std::shared_ptr<Nodes::TypeDfNode> Parser::TypeDfStatement()

--- a/tmpl-script/src/parser/type.cpp
+++ b/tmpl-script/src/parser/type.cpp
@@ -8,5 +8,26 @@ namespace AST
 
         return std::make_shared<Nodes::TypeNode>(target, target->GetLocation());
     }
+
+    std::shared_ptr<Nodes::TypeTemplateNode> Parser::TypeTemplate()
+    {
+        auto target = Id();
+
+        return std::make_shared<Nodes::TypeTemplateNode>(target, target->GetLocation());
+    }
+
+    std::shared_ptr<Nodes::TypeDfNode> Parser::TypeDfStatement()
+    {
+        auto loc = m_lexer->GetToken()->GetLocation();
+        Eat(TokenType::TypeDf);
+
+        auto tmpl = TypeTemplate();
+        
+        Eat(TokenType::Equal);
+
+        auto value = Type();
+
+        return std::make_shared<Nodes::TypeDfNode>(tmpl, value, loc);
+    }
 }
 

--- a/tmpl-script/src/typechecker.cpp
+++ b/tmpl-script/src/typechecker.cpp
@@ -13,6 +13,7 @@
 #include "../include/node/logical.h"
 #include "../include/node/macros.h"
 #include "../include/iterator.h"
+#include "include/node/instance.h"
 
 namespace Runtime
 {
@@ -39,6 +40,8 @@ namespace Runtime
                 return DiagnoseCondition(std::dynamic_pointer_cast<Condition>(node));
             case NodeType::Ternary:
                 return DiagnoseTernary(std::dynamic_pointer_cast<TernaryNode>(node));
+            case NodeType::Instance:
+                return DiagnoseInstance(std::dynamic_pointer_cast<InstanceNode>(node));
             case NodeType::Return:
             {
                 auto ret = std::dynamic_pointer_cast<ReturnNode>(node);
@@ -110,6 +113,9 @@ namespace Runtime
                     break;
                 case NodeType::FnDecl:
                     HandleFnDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt), false);
+                    break;
+                case NodeType::TypeDf:
+                    HandleTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(stmt));
                     break;
                 case NodeType::Extern:
                 {

--- a/tmpl-script/src/typechecker.cpp
+++ b/tmpl-script/src/typechecker.cpp
@@ -117,7 +117,7 @@ namespace Runtime
                     HandleFnDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt), false);
                     break;
                 case NodeType::TypeDf:
-                    HandleTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(stmt));
+                    HandleTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(stmt), false);
                     break;
                 case NodeType::Extern:
                 {

--- a/tmpl-script/src/typechecker.cpp
+++ b/tmpl-script/src/typechecker.cpp
@@ -42,6 +42,8 @@ namespace Runtime
                 return DiagnoseTernary(std::dynamic_pointer_cast<TernaryNode>(node));
             case NodeType::Instance:
                 return DiagnoseInstance(std::dynamic_pointer_cast<InstanceNode>(node));
+            case NodeType::Cast:
+                return DiagnoseTypeCasting(std::dynamic_pointer_cast<CastNode>(node));
             case NodeType::Return:
             {
                 auto ret = std::dynamic_pointer_cast<ReturnNode>(node);

--- a/tmpl-script/src/typechecker.cpp
+++ b/tmpl-script/src/typechecker.cpp
@@ -34,7 +34,7 @@ namespace Runtime
                 return DiagnoseFnCall(std::dynamic_pointer_cast<FunctionCall>(node));
             case NodeType::VarDecl:
                 HandleVarDeclaration(std::dynamic_pointer_cast<VarDeclaration>(node));
-                return nullptr;
+                return std::make_shared<ValType>("void");
             case NodeType::Condition:
                 return DiagnoseCondition(std::dynamic_pointer_cast<Condition>(node));
             case NodeType::Ternary:
@@ -50,14 +50,14 @@ namespace Runtime
                 DiagnoseNode(ifElse->GetCondition());
                 DiagnoseNode(ifElse->GetBody());
                 if (ifElse->GetElseNode() != nullptr) DiagnoseNode(ifElse->GetElseNode());
-                return nullptr;
+                return std::make_shared<ValType>("void");
             }
             case NodeType::Block:
             {
                 auto block = std::dynamic_pointer_cast<Statements::StatementsBody>(node);
                 auto scope = std::make_shared<Environment<TypeVariable>>(m_variables);
                 m_variables = scope;
-                PValType value = nullptr;
+                PValType value = std::make_shared<ValType>("void");
                 auto it = std::make_shared<Common::Iterator>(block->GetSize());
                 while (it->HasItems())
                 {
@@ -71,7 +71,7 @@ namespace Runtime
                     else
                     {
                         auto localVal = DiagnoseNode(node);
-                        if (node->IsBlock() && localVal != nullptr)
+                        if (node->IsBlock() && localVal != nullptr && !localVal->Compare(ValType("void")))
                         {
                             value = localVal;
                             break;
@@ -85,7 +85,7 @@ namespace Runtime
             }
             default:
                 // just skip the nodes we cannot typecheck
-                return nullptr;
+                return std::make_shared<ValType>("void");
         }
     }
 

--- a/tmpl-script/src/typechecker.cpp
+++ b/tmpl-script/src/typechecker.cpp
@@ -18,7 +18,7 @@ namespace Runtime
 {
     using namespace AST::Nodes;
 
-    ValueType TypeChecker::DiagnoseNode(std::shared_ptr<Node> node)
+    PValType TypeChecker::DiagnoseNode(std::shared_ptr<Node> node)
     {
         switch(node->GetType())
         {
@@ -34,7 +34,7 @@ namespace Runtime
                 return DiagnoseFnCall(std::dynamic_pointer_cast<FunctionCall>(node));
             case NodeType::VarDecl:
                 HandleVarDeclaration(std::dynamic_pointer_cast<VarDeclaration>(node));
-                return ValueType::Null;
+                return nullptr;
             case NodeType::Condition:
                 return DiagnoseCondition(std::dynamic_pointer_cast<Condition>(node));
             case NodeType::Ternary:
@@ -50,14 +50,14 @@ namespace Runtime
                 DiagnoseNode(ifElse->GetCondition());
                 DiagnoseNode(ifElse->GetBody());
                 if (ifElse->GetElseNode() != nullptr) DiagnoseNode(ifElse->GetElseNode());
-                return ValueType::Null;
+                return nullptr;
             }
             case NodeType::Block:
             {
                 auto block = std::dynamic_pointer_cast<Statements::StatementsBody>(node);
                 auto scope = std::make_shared<Environment<TypeVariable>>(m_variables);
                 m_variables = scope;
-                ValueType value = ValueType::Null;
+                PValType value = nullptr;
                 auto it = std::make_shared<Common::Iterator>(block->GetSize());
                 while (it->HasItems())
                 {
@@ -71,7 +71,7 @@ namespace Runtime
                     else
                     {
                         auto localVal = DiagnoseNode(node);
-                        if (node->IsBlock())
+                        if (node->IsBlock() && localVal != nullptr)
                         {
                             value = localVal;
                             break;
@@ -85,7 +85,7 @@ namespace Runtime
             }
             default:
                 // just skip the nodes we cannot typecheck
-                return ValueType::Null;
+                return nullptr;
         }
     }
 

--- a/tmpl-script/src/typechecker/assume.cpp
+++ b/tmpl-script/src/typechecker/assume.cpp
@@ -7,7 +7,7 @@ namespace Runtime
 {
     using namespace AST::Nodes;
 
-    void TypeChecker::AssumeIfElse(std::shared_ptr<Statements::IfElseStatement> ifElse, ValueType expected)
+    void TypeChecker::AssumeIfElse(std::shared_ptr<Statements::IfElseStatement> ifElse, PValType expected)
     {
         AssumeBlock(ifElse->GetBody(), expected);
         std::shared_ptr<Node> elseNode = ifElse->GetElseNode();
@@ -24,7 +24,7 @@ namespace Runtime
     }
 
     // Look for return statement inside block and check the type of returned value
-    void TypeChecker::AssumeBlock(std::shared_ptr<Statements::StatementsBody> body, ValueType expected)
+    void TypeChecker::AssumeBlock(std::shared_ptr<Statements::StatementsBody> body, PValType expected)
     {
         auto it = std::make_shared<Common::Iterator>(body->GetSize());
 
@@ -35,8 +35,8 @@ namespace Runtime
             if (stmt->GetType() == NodeType::Return)
             {
                 auto ret = std::dynamic_pointer_cast<ReturnNode>(stmt);
-                ValueType retType = DiagnoseNode(ret->GetValue());
-                if (retType != expected)
+                PValType retType = DiagnoseNode(ret->GetValue());
+                if (!retType->Compare(*expected))
                 {
                     Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
                     errorManager.UnexpectedReturnType(GetFilename(), expected, retType, ret->GetLocation());

--- a/tmpl-script/src/typechecker/cast.cpp
+++ b/tmpl-script/src/typechecker/cast.cpp
@@ -1,0 +1,13 @@
+#include "include/typechecker.h"
+
+namespace Runtime
+{
+    PValType TypeChecker::DiagnoseTypeCasting(std::shared_ptr<CastNode> cast)
+    {
+        auto target = DiagnoseNode(cast->GetExpr());
+        auto targetType = EvaluateType(GetFilename(), cast->GetTypeNode());
+
+        return CastType(GetFilename(), target, targetType, cast->GetTypeNode()->GetLocation(), m_type_definitions, "TypeError");
+    }
+}
+

--- a/tmpl-script/src/typechecker/fn_call.cpp
+++ b/tmpl-script/src/typechecker/fn_call.cpp
@@ -27,7 +27,7 @@ namespace Runtime
                     Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
                     errManager.UndeclaredFunction(GetFilename(), obj, targetType, "TypeError");
                     ReportError();
-                    return nullptr;
+                    return std::make_shared<ValType>("void");
                 }
 
                 std::shared_ptr<Environment<TypeFn>> typeEnv = m_type_functions->LookUp(targetType->GetName());
@@ -41,7 +41,7 @@ namespace Runtime
                     Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
                     errManager.UndeclaredFunction(GetFilename(), obj, targetType, "TypeError");
                     ReportError();
-                    return nullptr;
+                    return std::make_shared<ValType>("void");
                 }
 
                 fn = typeEnv->LookUp(fnName);
@@ -57,7 +57,7 @@ namespace Runtime
                     Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
                     errorManager.UndeclaredFunction(GetFilename(), idCallee, "TypeError");
                     ReportError();
-                    return nullptr;
+                    return std::make_shared<ValType>("void");
                 }
 
                 fn = m_functions->LookUp(fnName);
@@ -68,7 +68,7 @@ namespace Runtime
                 Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
                 errorManager.RaiseError("Invalid node for function call", "TypeError");
                 ReportError();
-                return nullptr;
+                return std::make_shared<ValType>("void");
             }
         }
 
@@ -77,7 +77,7 @@ namespace Runtime
             Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
             errorManager.PrivateFunctionError(GetFilename(), fnName, fn->GetModuleName(), callee->GetLocation(), fn->GetLocation(), "TypeError");
             ReportError();
-            return nullptr;
+            return std::make_shared<ValType>("void");
         }
 
         auto args = fnCall->GetArgs();

--- a/tmpl-script/src/typechecker/fn_call.cpp
+++ b/tmpl-script/src/typechecker/fn_call.cpp
@@ -8,7 +8,7 @@ namespace Runtime
 {
     using namespace AST::Nodes;
 
-    ValueType TypeChecker::DiagnoseFnCall(std::shared_ptr<FunctionCall> fnCall)
+    PValType TypeChecker::DiagnoseFnCall(std::shared_ptr<FunctionCall> fnCall)
     {
         // TODO: support for object member calls
         std::shared_ptr<Node> callee = fnCall->GetCallee();
@@ -21,15 +21,16 @@ namespace Runtime
             case AST::NodeType::ObjectMember:
             {
                 auto obj = std::dynamic_pointer_cast<ObjectMember>(callee);
-                ValueType targetType = DiagnoseNode(obj->GetObject());
-                if (!m_type_functions->HasItem(targetType))
+                PValType targetType = DiagnoseNode(obj->GetObject());
+                if (!m_type_functions->HasItem(targetType->GetName()))
                 {
                     Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
                     errManager.UndeclaredFunction(GetFilename(), obj, targetType, "TypeError");
-                    return ValueType::Null;
+                    ReportError();
+                    return nullptr;
                 }
 
-                std::shared_ptr<Environment<TypeFn>> typeEnv = m_type_functions->LookUp(targetType);
+                std::shared_ptr<Environment<TypeFn>> typeEnv = m_type_functions->LookUp(targetType->GetName());
                 assert(typeEnv != nullptr && "Type env should have been created.");
 
                 std::shared_ptr<Node> fnNameNode = obj->GetMember();
@@ -39,7 +40,8 @@ namespace Runtime
                 {
                     Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
                     errManager.UndeclaredFunction(GetFilename(), obj, targetType, "TypeError");
-                    return ValueType::Null;
+                    ReportError();
+                    return nullptr;
                 }
 
                 fn = typeEnv->LookUp(fnName);
@@ -54,7 +56,8 @@ namespace Runtime
                 {
                     Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
                     errorManager.UndeclaredFunction(GetFilename(), idCallee, "TypeError");
-                    return ValueType::Null;
+                    ReportError();
+                    return nullptr;
                 }
 
                 fn = m_functions->LookUp(fnName);
@@ -64,7 +67,8 @@ namespace Runtime
             {
                 Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
                 errorManager.RaiseError("Invalid node for function call", "TypeError");
-                return ValueType::Null;
+                ReportError();
+                return nullptr;
             }
         }
 
@@ -73,7 +77,7 @@ namespace Runtime
             Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
             errorManager.PrivateFunctionError(GetFilename(), fnName, fn->GetModuleName(), callee->GetLocation(), fn->GetLocation(), "TypeError");
             ReportError();
-            return ValueType::Null;
+            return nullptr;
         }
 
         auto args = fnCall->GetArgs();
@@ -97,8 +101,8 @@ namespace Runtime
             auto param = fn->GetItem(it->GetPosition());
             std::shared_ptr<Node> arg = (*args)[it->GetPosition()];
             it->Next();
-            ValueType valType = DiagnoseNode(arg);
-            if (valType != param->GetType())
+            PValType valType = DiagnoseNode(arg);
+            if (!valType->Compare(*param->GetType()))
             {
                 Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
                 errorManager.ArgMismatchType(

--- a/tmpl-script/src/typechecker/fn_decl.cpp
+++ b/tmpl-script/src/typechecker/fn_decl.cpp
@@ -6,6 +6,7 @@
 #include "../../include/node/identifier.h"
 #include "../../include/node/object_member.h"
 #include "include/interpreter/environment.h"
+#include "include/interpreter/value.h"
 #include <error.h>
 #include <memory>
 
@@ -16,7 +17,7 @@ namespace Runtime
     void TypeChecker::HandleFnDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported)
     {
         std::shared_ptr<Statements::StatementsBody> body = fnDecl->GetBody();
-        ValueType retType = EvaluateType(GetFilename(), fnDecl->GetReturnType());
+        PValType retType = EvaluateType(GetFilename(), fnDecl->GetReturnType());
 
         std::shared_ptr<Node> nameNode = fnDecl->GetName();
 
@@ -30,7 +31,7 @@ namespace Runtime
         {
             auto param = fnDecl->GetItem(it->GetPosition());
             it->Next();
-            ValueType paramType = EvaluateType(GetFilename(), param->GetType());
+            PValType paramType = EvaluateType(GetFilename(), param->GetType());
             std::string paramName = param->GetName()->GetName();
             std::shared_ptr<FnParam> fnParam = std::make_shared<FnParam>(paramType, paramName);
             fn->AddParam(fnParam);
@@ -50,11 +51,12 @@ namespace Runtime
             case AST::NodeType::ObjectMember:
             {
                 auto obj = std::dynamic_pointer_cast<ObjectMember>(nameNode);
-                ValueType targetType = EvaluateType(GetFilename(), obj->GetObject());
-                if (!m_type_functions->HasItem(targetType))
-                    m_type_functions->AddItem(targetType, std::make_shared<Environment<TypeFn>>());
+                assert(obj->GetObject()->GetType() == NodeType::Type && "Object target should be a type for type fn");
+                PValType targetType = EvaluateType(GetFilename(), std::dynamic_pointer_cast<TypeNode>(obj->GetObject()));
+                if (!m_type_functions->HasItem(targetType->GetName()))
+                    m_type_functions->AddItem(targetType->GetName(), std::make_shared<Environment<TypeFn>>());
 
-                std::shared_ptr<Environment<TypeFn>> typeEnv = m_type_functions->LookUp(targetType);
+                std::shared_ptr<Environment<TypeFn>> typeEnv = m_type_functions->LookUp(targetType->GetName());
                 assert(typeEnv != nullptr && "Type env should have been created.");
 
                 std::shared_ptr<Node> fnNameNode = obj->GetMember();
@@ -94,7 +96,7 @@ namespace Runtime
 
     void TypeChecker::HandleFnSignature(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported)
     {
-        ValueType retType = EvaluateType(GetFilename(), fnDecl->GetReturnType());
+        PValType retType = EvaluateType(GetFilename(), fnDecl->GetReturnType());
 
         std::shared_ptr<Node> nameNode = fnDecl->GetName();
         assert(nameNode->GetType() == NodeType::Identifier && "Name should be identifier");
@@ -107,7 +109,7 @@ namespace Runtime
         {
             auto param = fnDecl->GetItem(it->GetPosition());
             it->Next();
-            ValueType paramType = EvaluateType(GetFilename(), param->GetType());
+            PValType paramType = EvaluateType(GetFilename(), param->GetType());
             std::string paramName = param->GetName()->GetName();
             std::shared_ptr<FnParam> fnParam = std::make_shared<FnParam>(paramType, paramName);
             fn->AddParam(fnParam);

--- a/tmpl-script/src/typechecker/fn_decl.cpp
+++ b/tmpl-script/src/typechecker/fn_decl.cpp
@@ -63,6 +63,14 @@ namespace Runtime
                 auto typeDf = m_type_definitions->LookUp(typeName);
                 assert(typeDf != nullptr && "Type df shouldn't be null at this point.");
 
+                if (GetFilename() != typeDf->GetModuleName() && !typeDf->IsExported())
+                {
+                    Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+                    errorManager.PrivateTypeError(GetFilename(), typeDf->GetTypeName(), typeDf->GetModuleName(), nameNode->GetLocation(), typeDf->GetLocation(), "TypeError");
+                    ReportError();
+                    return;
+                }
+
                 // TODO: compare generics amount and names
                 if (typeDf->HasConstructor())
                 {
@@ -107,6 +115,14 @@ namespace Runtime
 
                 auto typeDf = m_type_definitions->LookUp(typeName);
                 assert(typeDf != nullptr && "Type df shouldn't be null at this point.");
+
+                if (GetFilename() != typeDf->GetModuleName() && !typeDf->IsExported())
+                {
+                    Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+                    errorManager.PrivateTypeError(GetFilename(), typeDf->GetTypeName(), typeDf->GetModuleName(), nameNode->GetLocation(), typeDf->GetLocation(), "TypeError");
+                    ReportError();
+                    return;
+                }
 
                 auto casts = typeDf->GetCastsEnv();
 

--- a/tmpl-script/src/typechecker/identifier.cpp
+++ b/tmpl-script/src/typechecker/identifier.cpp
@@ -12,7 +12,7 @@ namespace Runtime
 			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
 			errorManager.UndeclaredVariable(GetFilename(), identifier, "TypeError");
             ReportError();
-			return nullptr;
+			return std::make_shared<ValType>("void");
 		}
 		std::shared_ptr<TypeVariable> var = m_variables->LookUp(identifier->GetName());
 		return var->GetType();

--- a/tmpl-script/src/typechecker/identifier.cpp
+++ b/tmpl-script/src/typechecker/identifier.cpp
@@ -5,14 +5,14 @@ namespace Runtime
 {
     using namespace AST::Nodes;
 
-    ValueType TypeChecker::DiagnoseId(std::shared_ptr<IdentifierNode> identifier)
+    PValType TypeChecker::DiagnoseId(std::shared_ptr<IdentifierNode> identifier)
     {
 		if (!m_variables->HasItem(identifier->GetName()))
 		{
 			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
 			errorManager.UndeclaredVariable(GetFilename(), identifier, "TypeError");
             ReportError();
-			return ValueType::Null;
+			return nullptr;
 		}
 		std::shared_ptr<TypeVariable> var = m_variables->LookUp(identifier->GetName());
 		return var->GetType();

--- a/tmpl-script/src/typechecker/instance.cpp
+++ b/tmpl-script/src/typechecker/instance.cpp
@@ -20,6 +20,14 @@ namespace Runtime
         auto typeDf = m_type_definitions->LookUp(targetType->GetName());
         assert(typeDf != nullptr && "Type definition should not be not found at this point.");
 
+        if (GetFilename() != typeDf->GetModuleName() && !typeDf->IsExported())
+        {
+            Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+            errorManager.PrivateTypeError(GetFilename(), typeDf->GetTypeName(), typeDf->GetModuleName(), instance->GetLocation(), typeDf->GetLocation(), "TypeError");
+            ReportError();
+            return std::make_shared<ValType>("void");
+        }
+
         if (!typeDf->HasConstructor())
         {
             Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();

--- a/tmpl-script/src/typechecker/instance.cpp
+++ b/tmpl-script/src/typechecker/instance.cpp
@@ -1,0 +1,86 @@
+
+#include "include/interpreter/value.h"
+#include "include/iterator.h"
+#include "include/typechecker.h"
+
+namespace Runtime
+{
+    PValType TypeChecker::DiagnoseInstance(std::shared_ptr<InstanceNode> instance)
+    {
+        PValType targetType = EvaluateType(GetFilename(), instance->GetTarget());
+
+        if (!m_type_definitions->HasItem(targetType->GetName()))
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.TypeDoesNotExist(GetFilename(), targetType, instance->GetTarget()->GetLocation(), "TypeError");
+            ReportError();
+            return targetType;
+        }
+
+        auto typeDf = m_type_definitions->LookUp(targetType->GetName());
+        assert(typeDf != nullptr && "Type definition should not be not found at this point.");
+
+        if (!typeDf->HasConstructor())
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.TypeConstructorDoesNotExist(GetFilename(), targetType, instance->GetTarget()->GetLocation(), "TypeError");
+            ReportError();
+            return targetType;
+        }
+
+        auto fn = typeDf->GetConstructor();
+        assert(fn != nullptr && "Constructor fn should not be nullptr here.");
+
+        auto fnCall = instance->GetFunctionCall();
+        auto fnName = targetType->GetName() + "::constructor";
+
+        if (GetFilename() != fn->GetModuleName() && !fn->IsExported())
+        {
+            Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+            errorManager.PrivateFunctionError(GetFilename(), fnName, fn->GetModuleName(), fnCall->GetLocation(), fn->GetLocation(), "TypeError");
+            ReportError();
+            return targetType;
+        }
+
+        auto args = fnCall->GetArgs();
+
+        if (fn->GetParamsSize() != args->size())
+        {
+            Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+            errorManager.ArgsParamsExhausted(
+                    GetFilename(),
+                    fnName,
+                    args->size(),
+                    fn->GetParamsSize(),
+                    fnCall->GetLocation(), "TypeError");
+            ReportError();
+            return targetType;
+        }
+
+        auto it = std::make_shared<Common::Iterator>(fn->GetParamsSize());
+        while (it->HasItems())
+        {
+            auto param = fn->GetItem(it->GetPosition());
+            std::shared_ptr<Node> arg = (*args)[it->GetPosition()];
+            it->Next();
+            PValType val = DiagnoseNode(arg);
+            if (!val->Compare(*param->GetType()))
+            {
+                Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+                errorManager.ArgMismatchType(
+                        GetFilename(),
+                        param->GetName(),
+                        val,
+                        param->GetType(),
+                        arg->GetLocation(),
+                        "TypeError"
+                        );
+                ReportError();
+                return targetType;
+            }
+        }
+
+        return targetType;
+    }
+}
+

--- a/tmpl-script/src/typechecker/literal.cpp
+++ b/tmpl-script/src/typechecker/literal.cpp
@@ -5,29 +5,30 @@ namespace Runtime
 {
     using namespace AST::Nodes;
 
-    ValueType TypeChecker::DiagnoseLiteral(std::shared_ptr<LiteralNode> literal)
+    PValType TypeChecker::DiagnoseLiteral(std::shared_ptr<LiteralNode> literal)
     {
         switch(literal->GetLiteralType())
         {
             case LiteralType::INT:
-                return ValueType::Integer;
+                return std::make_shared<ValType>("int");
             case LiteralType::DOUBLE:
-                return ValueType::Double;
+                return std::make_shared<ValType>("double");
             case LiteralType::FLOAT:
-                return ValueType::Float;
+                return std::make_shared<ValType>("float");
             case LiteralType::STRING:
-                return ValueType::String;
+                // TODO: return list<char>
+                return std::make_shared<ValType>("string");
             case LiteralType::BOOL:
-                return ValueType::Bool;
+                return std::make_shared<ValType>("int");
             default:
                 break;
         }
 
         assert(literal->GetLiteralType() != LiteralType::_NULL &&
                 "Literal type shouldn't be left null");
-        assert(false && "Unreachable. Should handle all literal types");
 
-        return ValueType::Null;
+        assert(false && "Unreachable. Should handle all literal types");
+        return nullptr;
     }
 }
 

--- a/tmpl-script/src/typechecker/literal.cpp
+++ b/tmpl-script/src/typechecker/literal.cpp
@@ -19,7 +19,7 @@ namespace Runtime
                 // TODO: return list<char>
                 return std::make_shared<ValType>("string");
             case LiteralType::BOOL:
-                return std::make_shared<ValType>("int");
+                return std::make_shared<ValType>("bool");
             default:
                 break;
         }

--- a/tmpl-script/src/typechecker/module.cpp
+++ b/tmpl-script/src/typechecker/module.cpp
@@ -4,6 +4,7 @@
 #include "../../include/typechecker.h"
 #include "include/iterator.h"
 #include "include/node/function.h"
+#include "include/node/type.h"
 
 namespace fs = std::filesystem;
 
@@ -55,6 +56,9 @@ namespace Runtime
             case NodeType::VarDecl:
                 HandleVarDeclaration(std::dynamic_pointer_cast<VarDeclaration>(target));
                 break;
+            case NodeType::TypeDf:
+                HandleTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(target), true);
+                break;
             default:
                 assert(false && "Unreachable. Should be handled by parser.");
                 return;
@@ -87,7 +91,7 @@ namespace Runtime
                     HandleFnDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt), false);
                     break;
                 case NodeType::TypeDf:
-                    HandleTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(stmt));
+                    HandleTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(stmt), false);
                     break;
                 default:
                     {

--- a/tmpl-script/src/typechecker/module.cpp
+++ b/tmpl-script/src/typechecker/module.cpp
@@ -86,6 +86,9 @@ namespace Runtime
                 case NodeType::FnDecl:
                     HandleFnDeclaration(std::dynamic_pointer_cast<FunctionDeclaration>(stmt), false);
                     break;
+                case NodeType::TypeDf:
+                    HandleTypeDefinition(std::dynamic_pointer_cast<TypeDfNode>(stmt));
+                    break;
                 default:
                     {
                         Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();

--- a/tmpl-script/src/typechecker/type.cpp
+++ b/tmpl-script/src/typechecker/type.cpp
@@ -8,6 +8,31 @@ namespace Runtime
 {
     using namespace AST::Nodes;
 
+    PValType TypeChecker::GetRootType(std::string filename, PValType target, Location loc, TypeChecker::PTypeDfs typeDfs, std::string prefix)
+    {
+        auto typ = target;
+
+        while (typ != nullptr)
+        {
+            if (!typeDfs->HasItem(typ->GetName()))
+            {
+                Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+                errManager.TypeDoesNotExist(filename, typ, loc, prefix);
+                return std::make_shared<ValType>("void");
+            }
+
+            auto typDf = typeDfs->LookUp(typ->GetName());
+            assert(typDf != nullptr && "Found typ df should not be nullptr");
+
+            if (typDf->GetBaseType() == nullptr)
+                break;
+            else
+                typ = typDf->GetBaseType();
+        }
+
+        return typ;
+    }
+
     PValType TypeChecker::EvaluateType(std::string filename, std::shared_ptr<TypeNode> typeNode)
     {
         return std::make_shared<ValType>(typeNode->GetTypeName()->GetName());

--- a/tmpl-script/src/typechecker/type.cpp
+++ b/tmpl-script/src/typechecker/type.cpp
@@ -32,12 +32,10 @@ namespace Runtime
         // 2. check if "from" and "to" types are equal
         if (from->Compare(*to)) return to;
         // 3. check if "from" type's name is "to" type's basename
-        auto toDf = typeDfs->LookUp(to->GetName());
-        assert(toDf != nullptr && "To type's definition should not be null");
-        if (toDf->GetBaseType()->Compare(*from)) return to;
-        // 4. otherwise check if "from" type contains cast to "to" type in typeDf
         auto fromDf = typeDfs->LookUp(from->GetName());
         assert(fromDf != nullptr && "From type's definition should not be null");
+        if (fromDf->GetBaseType()->Compare(*to)) return to;
+        // 4. otherwise check if "from" type contains cast to "to" type in typeDf
         auto casts = fromDf->GetCastsEnv();
         if (casts->HasItem(to->GetName())) return to;
 

--- a/tmpl-script/src/typechecker/type.cpp
+++ b/tmpl-script/src/typechecker/type.cpp
@@ -34,7 +34,7 @@ namespace Runtime
         // 3. check if "from" type's name is "to" type's basename
         auto toDf = typeDfs->LookUp(to->GetName());
         assert(toDf != nullptr && "To type's definition should not be null");
-        if (toDf->GetBaseName() == from->GetName()) return to;
+        if (toDf->GetBaseType()->Compare(*from)) return to;
         // 4. otherwise check if "from" type contains cast to "to" type in typeDf
         auto fromDf = typeDfs->LookUp(from->GetName());
         assert(fromDf != nullptr && "From type's definition should not be null");

--- a/tmpl-script/src/typechecker/type.cpp
+++ b/tmpl-script/src/typechecker/type.cpp
@@ -16,6 +16,7 @@ namespace Runtime
     PValType TypeChecker::CastType(std::string filename, PValType from, PValType to, TypeChecker::PTypeDfs typeDfs)
     {
         // TODO:
+        // 0. check if "from" and "to" types are equal
         // 1. check if "from" type exists in typeDfs
         // 2. check if "to" type exists in typeDfs
         // 3. check if "to" type's name is "from" type's basename

--- a/tmpl-script/src/typechecker/type.cpp
+++ b/tmpl-script/src/typechecker/type.cpp
@@ -13,21 +13,21 @@ namespace Runtime
         return std::make_shared<ValType>(typeNode->GetTypeName()->GetName());
     }
 
-    PValType TypeChecker::CastType(std::string filename, PValType from, PValType to, Location loc, TypeChecker::PTypeDfs typeDfs)
+    PValType TypeChecker::CastType(std::string filename, PValType from, PValType to, Location loc, TypeChecker::PTypeDfs typeDfs, std::string prefix)
     {
         // 0. check if "from" type exists in typeDfs
         if (!typeDfs->HasItem(from->GetName()))
         {
             Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
-            errManager.TypeDoesNotExist(filename, from, loc, "TypeError");
-            return nullptr;
+            errManager.TypeDoesNotExist(filename, from, loc, prefix);
+            return std::make_shared<ValType>("void");
         }
         // 1. check if "to" type exists in typeDfs
         if (!typeDfs->HasItem(to->GetName()))
         {
             Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
-            errManager.TypeDoesNotExist(filename, to, loc, "TypeError");
-            return nullptr;
+            errManager.TypeDoesNotExist(filename, to, loc, prefix);
+            return std::make_shared<ValType>("void");
         }
         // 2. check if "from" and "to" types are equal
         if (from->Compare(*to)) return to;
@@ -42,8 +42,8 @@ namespace Runtime
         if (casts->HasItem(to->GetName())) return to;
 
         Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
-        errManager.TypeCastNotPossible(filename, from, to, loc, "TypeError");
-        return nullptr;
+        errManager.TypeCastNotPossible(filename, from, to, loc, prefix);
+        return std::make_shared<ValType>("void");
     }
 }
 

--- a/tmpl-script/src/typechecker/type.cpp
+++ b/tmpl-script/src/typechecker/type.cpp
@@ -16,11 +16,35 @@ namespace Runtime
     PValType TypeChecker::CastType(std::string filename, PValType from, PValType to, TypeChecker::PTypeDfs typeDfs)
     {
         // TODO:
-        // 0. check if "from" and "to" types are equal
-        // 1. check if "from" type exists in typeDfs
-        // 2. check if "to" type exists in typeDfs
-        // 3. check if "to" type's name is "from" type's basename
+        // 0. check if "from" type exists in typeDfs
+        if (!typeDfs->HasItem(from->GetName()))
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.TypeDoesNotExist(filename, from, "TypeError");
+            return nullptr;
+        }
+        // 1. check if "to" type exists in typeDfs
+        if (!typeDfs->HasItem(to->GetName()))
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.TypeDoesNotExist(filename, to, "TypeError");
+            return nullptr;
+        }
+        // 2. check if "from" and "to" types are equal
+        if (from->Compare(*to)) return to;
+        // 3. check if "from" type's name is "to" type's basename
+        auto toDf = typeDfs->LookUp(to->GetName());
+        assert(toDf != nullptr && "To type's definition should not be null");
+        if (toDf->GetBaseName() == from->GetName()) return to;
         // 4. otherwise check if "from" type contains cast to "to" type in typeDf
+        auto fromDf = typeDfs->LookUp(from->GetName());
+        assert(fromDf != nullptr && "From type's definition should not be null");
+        auto casts = fromDf->GetCastsEnv();
+        if (casts->HasItem(to->GetName())) return to;
+
+        Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+        errManager.TypeCastNotPossible(filename, from, to, "TypeError");
+        return nullptr;
     }
 }
 

--- a/tmpl-script/src/typechecker/type.cpp
+++ b/tmpl-script/src/typechecker/type.cpp
@@ -13,21 +13,20 @@ namespace Runtime
         return std::make_shared<ValType>(typeNode->GetTypeName()->GetName());
     }
 
-    PValType TypeChecker::CastType(std::string filename, PValType from, PValType to, TypeChecker::PTypeDfs typeDfs)
+    PValType TypeChecker::CastType(std::string filename, PValType from, PValType to, Location loc, TypeChecker::PTypeDfs typeDfs)
     {
-        // TODO:
         // 0. check if "from" type exists in typeDfs
         if (!typeDfs->HasItem(from->GetName()))
         {
             Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
-            errManager.TypeDoesNotExist(filename, from, "TypeError");
+            errManager.TypeDoesNotExist(filename, from, loc, "TypeError");
             return nullptr;
         }
         // 1. check if "to" type exists in typeDfs
         if (!typeDfs->HasItem(to->GetName()))
         {
             Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
-            errManager.TypeDoesNotExist(filename, to, "TypeError");
+            errManager.TypeDoesNotExist(filename, to, loc, "TypeError");
             return nullptr;
         }
         // 2. check if "from" and "to" types are equal
@@ -43,7 +42,7 @@ namespace Runtime
         if (casts->HasItem(to->GetName())) return to;
 
         Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
-        errManager.TypeCastNotPossible(filename, from, to, "TypeError");
+        errManager.TypeCastNotPossible(filename, from, to, loc, "TypeError");
         return nullptr;
     }
 }

--- a/tmpl-script/src/typechecker/type.cpp
+++ b/tmpl-script/src/typechecker/type.cpp
@@ -1,58 +1,16 @@
 
 
 #include "../../include/typechecker.h"
+#include "include/interpreter/value.h"
+#include <memory>
 
 namespace Runtime
 {
     using namespace AST::Nodes;
 
-    ValueType TypeChecker::EvaluateType(std::string filename, std::shared_ptr<Node> typeNode)
+    PValType TypeChecker::EvaluateType(std::string filename, std::shared_ptr<TypeNode> typeNode)
     {
-		if (typeNode->GetType() == NodeType::Identifier)
-		{
-			auto id = std::dynamic_pointer_cast<IdentifierNode>(typeNode);
-			if (id->GetName() == "string")
-			{
-				return ValueType::String;
-			}
-			else if (id->GetName() == "double")
-			{
-				return ValueType::Double;
-			}
-			else if (id->GetName() == "float")
-			{
-				return ValueType::Float;
-			}
-			else if (id->GetName() == "int")
-			{
-				return ValueType::Integer;
-			}
-			else if (id->GetName() == "bool")
-            {
-                return ValueType::Bool;
-            }
-			else if (id->GetName() == "void")
-            {
-                return ValueType::Null;
-            }
-			else
-			{
-				Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-				errorManager.UndefinedType(filename, id->GetName(), id->GetLocation(), "TypeError");
-                // Try reporting instead of exiting
-                exit(-1);
-			}
-		}
-		else
-		{
-			// TODO: support for complex types, e.g. inline objects, generic types
-			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-			errorManager.RaiseError("Unsupported node type for type: " + std::to_string((int)typeNode->GetType()), "TypeError");
-            // TODO: try reporint instead of exiting
-            exit(-1);
-		}
-
-		return ValueType::Null;
+        return std::make_shared<ValType>(typeNode->GetTypeName()->GetName());
     }
 }
 

--- a/tmpl-script/src/typechecker/type.cpp
+++ b/tmpl-script/src/typechecker/type.cpp
@@ -12,5 +12,14 @@ namespace Runtime
     {
         return std::make_shared<ValType>(typeNode->GetTypeName()->GetName());
     }
+
+    PValType TypeChecker::CastType(std::string filename, PValType from, PValType to, TypeChecker::PTypeDfs typeDfs)
+    {
+        // TODO:
+        // 1. check if "from" type exists in typeDfs
+        // 2. check if "to" type exists in typeDfs
+        // 3. check if "to" type's name is "from" type's basename
+        // 4. otherwise check if "from" type contains cast to "to" type in typeDf
+    }
 }
 

--- a/tmpl-script/src/typechecker/typedf.cpp
+++ b/tmpl-script/src/typechecker/typedf.cpp
@@ -3,7 +3,7 @@
 
 namespace Runtime
 {
-    void TypeChecker::HandleTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn)
+    void TypeChecker::HandleTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn, bool exported)
     {
         // check if type already exists
         auto typeName = typeDfn->GetTypeTemplate();
@@ -19,7 +19,7 @@ namespace Runtime
         auto baseType = typeDfn->GetTypeValue();
 
         std::string key = typeName->GetTypeName()->GetName();
-        auto typeDf = std::make_shared<TypeDf>(key, EvaluateType(GetFilename(), baseType));
+        auto typeDf = std::make_shared<TypeDf>(key, EvaluateType(GetFilename(), baseType), GetFilename(), exported, typeDfn->GetLocation());
 
         m_type_definitions->AddItem(key, typeDf);
     }

--- a/tmpl-script/src/typechecker/typedf.cpp
+++ b/tmpl-script/src/typechecker/typedf.cpp
@@ -19,7 +19,7 @@ namespace Runtime
         auto baseType = typeDfn->GetTypeValue();
 
         std::string key = typeName->GetTypeName()->GetName();
-        auto typeDf = std::make_shared<TypeDf>(key, baseType->GetTypeName()->GetName());
+        auto typeDf = std::make_shared<TypeDf>(key, EvaluateType(GetFilename(), baseType));
 
         m_type_definitions->AddItem(key, typeDf);
     }

--- a/tmpl-script/src/typechecker/typedf.cpp
+++ b/tmpl-script/src/typechecker/typedf.cpp
@@ -1,0 +1,27 @@
+
+#include "include/typechecker.h"
+
+namespace Runtime
+{
+    void TypeChecker::HandleTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn)
+    {
+        // check if type already exists
+        auto typeName = typeDfn->GetTypeTemplate();
+
+        if (m_type_definitions->HasItem(typeName->GetTypeName()->GetName()))
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.TypeRedeclaration(GetFilename(), typeName, "TypeError");
+            ReportError();
+            return;
+        }
+
+        auto baseType = typeDfn->GetTypeValue();
+
+        std::string key = typeName->GetTypeName()->GetName();
+        auto typeDf = std::make_shared<TypeDf>(key, baseType->GetTypeName()->GetName());
+
+        m_type_definitions->AddItem(key, typeDf);
+    }
+}
+

--- a/tmpl-script/src/typechecker/var_decl.cpp
+++ b/tmpl-script/src/typechecker/var_decl.cpp
@@ -15,14 +15,6 @@ namespace Runtime
 
         CastType(GetFilename(), varValueType, varType, m_type_definitions);
 
-        // This check should be unnecessary as cast type will throw error if failed casting
-		/*if (!varType->Compare(*varValueType))*/
-		/*{*/
-		/*	Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();*/
-		/*	errorManager.VarMismatchType(GetFilename(), varName, varValueType, varType, varDecl->GetLocation(), "TypeError");*/
-		/*          ReportError();*/
-		/*}*/
-
 		std::shared_ptr<TypeVariable> var = std::make_shared<TypeVariable>(varType, varDecl->Editable());
 
         if (m_variables->Contains(varName))

--- a/tmpl-script/src/typechecker/var_decl.cpp
+++ b/tmpl-script/src/typechecker/var_decl.cpp
@@ -1,6 +1,7 @@
 
 
 #include "../../include/typechecker.h"
+#include "include/interpreter/value.h"
 
 namespace Runtime
 {
@@ -8,9 +9,9 @@ namespace Runtime
 
     void TypeChecker::HandleVarDeclaration(std::shared_ptr<VarDeclaration> varDecl)
     {
-		ValueType varType = EvaluateType(GetFilename(), varDecl->GetType());
+		PValType varType = EvaluateType(GetFilename(), varDecl->GetType());
 		std::string varName = *varDecl->GetName();
-		ValueType varValueType = DiagnoseNode(varDecl->GetValue());
+		PValType varValueType = DiagnoseNode(varDecl->GetValue());
 
 		if (varType != varValueType)
 		{

--- a/tmpl-script/src/typechecker/var_decl.cpp
+++ b/tmpl-script/src/typechecker/var_decl.cpp
@@ -13,7 +13,7 @@ namespace Runtime
 		std::string varName = *varDecl->GetName();
 		PValType varValueType = DiagnoseNode(varDecl->GetValue());
 
-		if (varType != varValueType)
+		if (!varType->Compare(*varValueType))
 		{
 			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
 			errorManager.VarMismatchType(GetFilename(), varName, varValueType, varType, varDecl->GetLocation(), "TypeError");

--- a/tmpl-script/src/typechecker/var_decl.cpp
+++ b/tmpl-script/src/typechecker/var_decl.cpp
@@ -13,7 +13,13 @@ namespace Runtime
 		std::string varName = *varDecl->GetName();
 		PValType varValueType = DiagnoseNode(varDecl->GetValue());
 
-        CastType(GetFilename(), varValueType, varType, m_type_definitions);
+        if (!varType->Compare(*varValueType))
+        {
+			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
+			errorManager.VarMismatchType(GetFilename(), varName, varValueType, varType, varDecl->GetLocation(), "TypeError");
+            ReportError();
+			return;
+        }
 
 		std::shared_ptr<TypeVariable> var = std::make_shared<TypeVariable>(varType, varDecl->Editable());
 

--- a/tmpl-script/src/typechecker/var_decl.cpp
+++ b/tmpl-script/src/typechecker/var_decl.cpp
@@ -13,12 +13,15 @@ namespace Runtime
 		std::string varName = *varDecl->GetName();
 		PValType varValueType = DiagnoseNode(varDecl->GetValue());
 
-		if (!varType->Compare(*varValueType))
-		{
-			Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();
-			errorManager.VarMismatchType(GetFilename(), varName, varValueType, varType, varDecl->GetLocation(), "TypeError");
-            ReportError();
-		}
+        CastType(GetFilename(), varValueType, varType, m_type_definitions);
+
+        // This check should be unnecessary as cast type will throw error if failed casting
+		/*if (!varType->Compare(*varValueType))*/
+		/*{*/
+		/*	Prelude::ErrorManager &errorManager = Prelude::ErrorManager::getInstance();*/
+		/*	errorManager.VarMismatchType(GetFilename(), varName, varValueType, varType, varDecl->GetLocation(), "TypeError");*/
+		/*          ReportError();*/
+		/*}*/
 
 		std::shared_ptr<TypeVariable> var = std::make_shared<TypeVariable>(varType, varDecl->Editable());
 


### PR DESCRIPTION
A new feature that allows users define their custom types and use them. Custom types have a lot of features like custom constructors, casters and type inheritance.

## Example of Defining a Custom Type

In order to define custom type, you need to decide what base type you will use for your type. 

### Built-In Types (at the moment)
1. int
2. float
3. double
4. bool
5. string

After you decided which type you want to use, you can define your type using following syntax:

```
typedf Integer = int;
```

In the above example we've defined custom type named `Integer` that inherits from `int`. That means that `int` is now the base type of `Integer`

## Using Your Custom Type

After type definition you should declare type's constructor in order to define variables within that type.

```
fn @construct Integer(int value) : Integer {
    return value;
}
```

Your constructor should return your type's base type. In above example the constructor of `Integer` should return `int`, because `int` was specified as base type that `Integer` inherits from.

After that you can define a variable with your custom type

```
->main {
    var Integer test = new Integer(50);
    # use your type...
}
```

## Type Casting

In order to cast one type to another you need to use following syntax

```
->main {
    var float PI = 3.1415;
    var int PI_int = (int)PI;
    println(PI_int.tostring()); # expected "3"
}
```

Going further with above example, you can do down-casting any time for any custom defined type. Down-casting is a casting of the type to it's parent type (base type).

Here's an example of down-casting

```
typedf Integer = int;

fn @construct Integer(int value) : Integer {
    return value;
}

->main {
    var Integer test = new Integer(50);
    var int native = (int)test;
    println(native.tostring()); # expected "50"
}
```

In above example down-casting to `int` will only work if `Integer` inherits from `int`.

## Custom Type Casters

If you want your type to be casted to another type, for example our `Integer` to `string`, then you can implement custom caster for your type

Here is an example of creating custom type caster for your own type

```
typedf Integer = int;

fn @construct Integer(int value) : Integer {
    return value;
}

fn @cast(Integer) -> string {
    return ((int)self).tostring();
}

->main {
    var Integer test = new Integer(100);
    var string data = (string)test;
    println(data); # expected: "100"
}
```

