### PR TITLE
Assignments Support

### DIFF
--- a/example/.tmpl/assign.tmpl
+++ b/example/.tmpl/assign.tmpl
@@ -1,0 +1,8 @@
+
+
+->main {
+    var int test = 50;
+    test = 100;
+    return test;
+}
+

--- a/tmpl-script/include/error.h
+++ b/tmpl-script/include/error.h
@@ -78,6 +78,8 @@ namespace Prelude
 		void UndeclaredVariable(std::string filename, std::shared_ptr<AST::Nodes::IdentifierNode> id, std::string prefix);
 		void UndefinedType(std::string filename, std::string name, AST::Location loc, std::string prefix);
 		void VarMismatchType(std::string filename, std::string name, Runtime::PValType type, Runtime::PValType expectedType, AST::Location loc, std::string prefix);
+		void AssignMismatchType(std::string filename, std::string name, Runtime::PValType type, Runtime::PValType expectedType, AST::Location loc, std::string prefix);
+        void ConstAssignment(std::string filename, std::string name, AST::Location loc, std::string prefix);
         void VarAlreadyExists(std::string filename, std::string name, AST::Location loc, std::string prefix);
         void FunctionRedeclaration(std::string filename, std::string name, AST::Location loc, std::string declFilename, AST::Location declLoc, std::string prefix);
     public: // CliRunner

--- a/tmpl-script/include/interpreter.h
+++ b/tmpl-script/include/interpreter.h
@@ -1,6 +1,7 @@
 #ifndef INTERPRETER_H
 #define INTERPRETER_H
 #include <memory>
+#include "include/node/assign.h"
 #include "include/node/instance.h"
 #include "include/node/statement.h"
 #include "include/node/type.h"
@@ -95,6 +96,7 @@ namespace Runtime
         void EvaluateFunctionDeclaration(std::shared_ptr<FunctionDeclaration> fnDecl, bool exported, bool externed); // DONE
         void EvaluateExportStatement(std::shared_ptr<ExportStatement> exportStmt); // DONE
         void EvaluateTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn, bool exported);
+        void EvaluateAssignment(std::shared_ptr<AssignmentNode> assignment);
 
     private:
         inline std::string GetFilename() const { return m_filename; }

--- a/tmpl-script/include/interpreter/environment.h
+++ b/tmpl-script/include/interpreter/environment.h
@@ -26,7 +26,12 @@ namespace Runtime
 			: m_type(type), m_value(value), m_editable(editable) {}
 
 	public:
-		inline std::shared_ptr<Value> GetValue() { return m_value; }
+		inline std::shared_ptr<Value> GetValue() const { return m_value; }
+        inline PValType GetType() const { return m_type; }
+        inline bool IsEditable() const { return m_editable; }
+
+    public:
+        void SetValue(std::shared_ptr<Value> newValue) { m_value = newValue; }
 	};
 
 	class Procedure

--- a/tmpl-script/include/node.h
+++ b/tmpl-script/include/node.h
@@ -36,6 +36,7 @@ namespace AST
         TypeDf,
         Instance,
         Cast,
+        Assign,
     };
 
 	class Node

--- a/tmpl-script/include/node/assign.h
+++ b/tmpl-script/include/node/assign.h
@@ -1,0 +1,36 @@
+
+#ifndef ASSIGN_NODE_H_
+#define ASSIGN_NODE_H_
+
+#include <memory>
+#include "include/location.h"
+#include "include/node.h"
+
+namespace AST::Nodes
+{
+    class AssignmentNode : public Node
+    {
+    public:
+        using PNode = std::shared_ptr<Node>;
+    private:
+        PNode m_assignee;
+        PNode m_value;
+
+    public:
+        AssignmentNode(PNode assignee, PNode value, Location loc)
+            : m_assignee(assignee), m_value(value), Node(loc) { }
+
+	public:
+		inline NodeType GetType() const override { return NodeType::Assign; }
+
+	public:
+		std::string Format() const override;
+
+    public:
+        inline PNode GetAssignee() const { return m_assignee; }
+        inline PNode GetValue() const { return m_value; }
+    };
+}
+
+#endif // ASSIGN_NODE_H_
+

--- a/tmpl-script/include/parser.h
+++ b/tmpl-script/include/parser.h
@@ -46,6 +46,7 @@ namespace AST
 		std::shared_ptr<Node> Expr();
 		std::shared_ptr<Node> Cond();
 		std::shared_ptr<Node> Ternary();
+		std::shared_ptr<Node> Assignment();
 
     private: // Checkers
         bool IsTypeCastAhead();

--- a/tmpl-script/include/typechecker.h
+++ b/tmpl-script/include/typechecker.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include "include/helper.h"
 #include "include/interpreter.h"
+#include "include/node/assign.h"
 #include "include/node/cast.h"
 #include "include/node/instance.h"
 #include "include/node/logical.h"
@@ -117,6 +118,7 @@ namespace Runtime
         void HandleModule(std::shared_ptr<ProgramNode> program); // DONE
         void HandleExportStatement(std::shared_ptr<ExportStatement> exportStmt); // DONE
         void HandleTypeDefinition(std::shared_ptr<TypeDfNode> typeDfn, bool exported);
+        void HandleAssignment(std::shared_ptr<AssignmentNode> assignment);
 
     private:
         void AssumeBlock(std::shared_ptr<Statements::StatementsBody> body, PValType expected); // DONE

--- a/tmpl-script/src/error.cpp
+++ b/tmpl-script/src/error.cpp
@@ -98,6 +98,21 @@ namespace Prelude
             << "' but got '" << *type << "'" << std::endl;
         if (prefix != "TypeError") std::exit(-1);
 	}
+	void ErrorManager::AssignMismatchType(std::string filename, std::string name, Runtime::PValType type, Runtime::PValType expectedType, Location loc, std::string prefix)
+	{
+        // TODO: allow defining double type variable with float value (casting) and opposite direction
+        LogFileLocation(filename, loc, prefix);
+        std::cerr << "Type mismatch for assignment of variable '" << name
+            << "'. Expected type '" << *expectedType
+            << "' but got '" << *type << "'" << std::endl;
+        if (prefix != "TypeError") std::exit(-1);
+	}
+    void ErrorManager::ConstAssignment(std::string filename, std::string name, AST::Location loc, std::string prefix)
+    {
+        LogFileLocation(filename, loc, prefix);
+        std::cerr << "Cannot reassign a constant '" << name << "'" << std::endl;
+        if (prefix != "TypeError") std::exit(-1);
+    }
 	void ErrorManager::OperandMismatchType(std::string filename, Runtime::PValType leftType, Runtime::PValType rightType, Location loc, std::string prefix)
 	{
         LogFileLocation(filename, loc, prefix);

--- a/tmpl-script/src/interpreter.cpp
+++ b/tmpl-script/src/interpreter.cpp
@@ -1,4 +1,5 @@
 
+#include "include/node/assign.h"
 #include "include/node/instance.h"
 #include <cassert>
 #include <memory>
@@ -142,6 +143,11 @@ namespace Runtime
             return EvaluateInstance(std::dynamic_pointer_cast<InstanceNode>(node));
         case NodeType::Cast:
             return EvaluateTypeCasting(std::dynamic_pointer_cast<CastNode>(node));
+        case NodeType::Assign:
+        {
+            EvaluateAssignment(std::dynamic_pointer_cast<AssignmentNode>(node));
+            break;
+        }
         case NodeType::Block:
         {
             auto block = std::dynamic_pointer_cast<Statements::StatementsNode>(node);

--- a/tmpl-script/src/interpreter/assign.cpp
+++ b/tmpl-script/src/interpreter/assign.cpp
@@ -1,0 +1,43 @@
+
+#include <memory>
+#include "include/interpreter.h"
+#include "include/node/identifier.h"
+
+namespace Runtime
+{
+    void Interpreter::EvaluateAssignment(std::shared_ptr<AssignmentNode> assignment)
+    {
+        // TODO: support for object member reassignment
+        assert(assignment->GetAssignee()->GetType() == NodeType::Identifier && "Assignee should be an identifier.");
+        // TODO: support for object members name
+        std::string varName = std::dynamic_pointer_cast<IdentifierNode>(assignment->GetAssignee())->GetName();
+
+        if (!m_variables->HasItem(varName))
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.UndeclaredVariable(GetFilename(), std::dynamic_pointer_cast<IdentifierNode>(assignment->GetAssignee()), "RuntimeError");
+            return;
+        }
+
+        auto variable = m_variables->LookUp(varName);
+
+        if (!variable->IsEditable())
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.ConstAssignment(GetFilename(), varName, assignment->GetLocation(), "RuntimeError");
+            return;
+        }
+
+        auto newValue = Execute(assignment->GetValue());
+
+        if (!variable->GetType()->Compare(*newValue->GetType()))
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.AssignMismatchType(GetFilename(), varName, newValue->GetType(), variable->GetType(), assignment->GetLocation(), "RuntimeError");
+            return;
+        }
+
+        variable->SetValue(newValue);
+    }
+}
+

--- a/tmpl-script/src/node/assign.cpp
+++ b/tmpl-script/src/node/assign.cpp
@@ -1,0 +1,11 @@
+
+#include "include/node/assign.h"
+
+namespace AST::Nodes
+{
+    std::string AssignmentNode::Format() const 
+    {
+        return "Assign(" + m_assignee->Format() + " = " + m_value->Format() + ")";
+    }
+}
+

--- a/tmpl-script/src/parser.cpp
+++ b/tmpl-script/src/parser.cpp
@@ -108,7 +108,7 @@ namespace AST
             break;
         }
 		default:
-			stmt = Ternary();
+			stmt = Assignment();
 			Eat(TokenType::Semicolon);
 			break;
 		}

--- a/tmpl-script/src/parser/expr.cpp
+++ b/tmpl-script/src/parser/expr.cpp
@@ -4,11 +4,30 @@
 #include "../../include/node/literal.h"
 #include "../../include/node/logical.h"
 #include "../../include/node/unary.h"
+#include "include/node/assign.h"
 #include "include/node/instance.h"
 #include "include/token.h"
 
 namespace AST
 {
+    std::shared_ptr<Node> Parser::Assignment()
+    {
+        // TODO: support for object member assignment
+        if (m_lexer->GetToken()->GetType() == TokenType::Id)
+        {
+            // TODO: when support object members use m_lexer.SaveState to look for "="
+            if (m_lexer->SeekToken() != nullptr && m_lexer->SeekToken()->GetType() == TokenType::Equal)
+            {
+                auto assignee = Id();
+                Eat(TokenType::Equal);
+                auto expr = Ternary();
+                return std::make_shared<Nodes::AssignmentNode>(assignee, expr, assignee->GetLocation());
+            }
+        }
+
+        return Ternary();
+    }
+
 	std::shared_ptr<Node> Parser::Ternary()
 	{
 		std::shared_ptr<Node> result = Cond();

--- a/tmpl-script/src/typechecker.cpp
+++ b/tmpl-script/src/typechecker.cpp
@@ -13,6 +13,7 @@
 #include "../include/node/logical.h"
 #include "../include/node/macros.h"
 #include "../include/iterator.h"
+#include "include/node/assign.h"
 #include "include/node/instance.h"
 
 namespace Runtime
@@ -44,6 +45,11 @@ namespace Runtime
                 return DiagnoseInstance(std::dynamic_pointer_cast<InstanceNode>(node));
             case NodeType::Cast:
                 return DiagnoseTypeCasting(std::dynamic_pointer_cast<CastNode>(node));
+            case NodeType::Assign:
+            {
+                HandleAssignment(std::dynamic_pointer_cast<AssignmentNode>(node));
+                return std::make_shared<ValType>("void");
+            }
             case NodeType::Return:
             {
                 auto ret = std::dynamic_pointer_cast<ReturnNode>(node);

--- a/tmpl-script/src/typechecker/assign.cpp
+++ b/tmpl-script/src/typechecker/assign.cpp
@@ -1,0 +1,39 @@
+
+#include "include/typechecker.h"
+
+namespace Runtime
+{
+    void TypeChecker::HandleAssignment(std::shared_ptr<AssignmentNode> assignment)
+    {
+        // TODO: support for object member reassignment
+        assert(assignment->GetAssignee()->GetType() == NodeType::Identifier && "Assignee should be an identifier.");
+        // TODO: support for object members name
+        std::string varName = std::dynamic_pointer_cast<IdentifierNode>(assignment->GetAssignee())->GetName();
+
+        if (!m_variables->HasItem(varName))
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.UndeclaredVariable(GetFilename(), std::dynamic_pointer_cast<IdentifierNode>(assignment->GetAssignee()), "TypeError");
+            ReportError();
+        }
+
+        auto variable = m_variables->LookUp(varName);
+
+        if (!variable->IsEditable())
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.ConstAssignment(GetFilename(), varName, assignment->GetLocation(), "TypeError");
+            ReportError();
+        }
+
+        auto newValType = DiagnoseNode(assignment->GetValue());
+
+        if (!variable->GetType()->Compare(*newValType))
+        {
+            Prelude::ErrorManager& errManager = Prelude::ErrorManager::getInstance();
+            errManager.AssignMismatchType(GetFilename(), varName, newValType, variable->GetType(), assignment->GetLocation(), "TypeError");
+            ReportError();
+        }
+    }
+}
+


### PR DESCRIPTION
Variables can be reassigned now

## Example

Here is an example of reassigning a variable

```
->main {
    var int test = 50;
    test = 100;
    println(test.tostring()); # expected: "100"
}
```

## Errors Handling

By assignments typechecker and interpreter are handling following errors: `constant reassign` and `type mismatch`

Code example

```
->main {
    const int test = 50;
    test = "100";
    return test;
}
```

Output

```
[.tmpl/assign.tmpl:5:8] TypeError: Cannot reassign a constant 'test'
[.tmpl/assign.tmpl:5:8] TypeError: Type mismatch for assignment of variable 'test'. Expected type 'int' but got 'string'
PreLaunchError:: Found 2 type errors. Exiting...
```